### PR TITLE
Add LS5_fc product definition

### DIFF
--- a/dev/products/fc/ls5_fc_albers.yaml
+++ b/dev/products/fc/ls5_fc_albers.yaml
@@ -1,0 +1,42 @@
+name: ls5_fc_albers
+
+description: Landsat 5 Fractional Cover 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)
+metadata_type: eo
+
+metadata:
+  platform:
+    code: LANDSAT_5
+  format:
+    name: GeoTIFF
+  instrument:
+    name: TM
+  product_type: fractional_cover
+
+storage:
+  crs: EPSG:3577
+  resolution:
+          x: 25
+          y: -25
+  dimension_order: ['time', 'y', 'x']
+
+measurements:
+    - name: BS
+      units: "percent"
+      dtype: uint8
+      nodata: 255
+      aliases: ["bare"]
+    - name: PV
+      units: "percent"
+      dtype: uint8
+      nodata: 255
+      aliases: ["green_veg"]
+    - name: NPV
+      units: "percent"
+      dtype: uint8
+      nodata: 255
+      aliases: ["dead_veg"]
+    - name: UE
+      units: "1"
+      dtype: uint8
+      nodata: 255
+      aliases: ["err"]


### PR DESCRIPTION
Add munged LS5_fc product definition - should be consistent with the Landsat 5 Fractional cover that has been uploaded to AWS. (untested)