### PR TITLE
Add in CORS domains and a reasonable home camera over Australia.

### DIFF
--- a/dev/terria/dea.json
+++ b/dev/terria/dea.json
@@ -1,4 +1,16 @@
 {
+   "corsDomains": [
+      "ga.gov.au",
+      "gsky-dev.nci.org.au",
+      "gsky-test.nci.org.au",
+      "gsky.nci.org.au"
+   ],
+   "homeCamera": {
+      "north": -8,
+      "east": 158,
+      "south": -45,
+      "west": 109
+   },
    "catalog": [
       {
          "name": "GSKY Geoglam (prod)",


### PR DESCRIPTION
This will make it so that the DEA ODC and GSKY layers are known to have CORS enabled so the terriajs-server proxy will not be used.

It will also give a reasonable home camera view on load.