### PR TITLE
Tweak DEA CORS domain. Make GSKY Prod use TLS.

### DIFF
--- a/dev/terria/dea.json
+++ b/dev/terria/dea.json
@@ -1,6 +1,6 @@
 {
    "corsDomains": [
-      "ga.gov.au",
+      "dea.ga.gov.au",
       "gsky-dev.nci.org.au",
       "gsky-test.nci.org.au",
       "gsky.nci.org.au"
@@ -20,7 +20,7 @@
       {
          "name": "GSKY DEA (prod)",
          "type": "wms-getCapabilities",
-         "url": "http://gsky.nci.org.au/ows"
+         "url": "https://gsky.nci.org.au/ows"
       },
       {
          "name": "GSKY with legends (prod)",
@@ -31,7 +31,7 @@
                "name": "Daily Water Observation Feature Layer",
                "type": "wms",
                "layers": "wofs",
-               "url": "http://gsky.nci.org.au/ows",
+               "url": "https://gsky.nci.org.au/ows",
                "legendUrl": "http://dea-public-data.s3-ap-southeast-2.amazonaws.com/WOfS/WOFLs/v2.1.0/wofs-legend.svg",
             }
          ]


### PR DESCRIPTION
Not all GA layers are CORS enabled so being more specific ensures non-DEA layers will go via the proxy.
Make the GSKY Prod URL use HTTPS - otherwise when accessing Terria-Cube on HTTPS but GSKY on HTTP the proxy is used.