### PR TITLE
Decrease the zoom level for wofls layer

### DIFF
--- a/dev/services/wms/ows/wms_cfg.py
+++ b/dev/services/wms/ows/wms_cfg.py
@@ -2356,7 +2356,7 @@ Data is provided as Water Observation Feature Layers (WOFLs), in a 1 to 1 relati
                 #"pq_band": "water",
                 # Min zoom factor - sets the zoom level where the cutover from indicative polygons
                 # to actual imagery occurs.
-                "min_zoom_factor": 15.0,
+                "min_zoom_factor": 35.0,
                 # The fill-colour of the indicative polygons when zoomed out.
                 # Triplets (rgb) or quadruplets (rgba) of integers 0-255.
                 "zoomed_out_fill_colour": [200, 180, 180, 160],


### PR DESCRIPTION
On higher level zoom factor, if the dataset is derived from `landsat7`  issues with overviews