### PR TITLE
Fix the barest_earth_mosaic tile size

### DIFF
--- a/dev/products/ls8-bare-earth/landsat8_barest_earth_mosaic.yaml
+++ b/dev/products/ls8-bare-earth/landsat8_barest_earth_mosaic.yaml
@@ -13,8 +13,8 @@ storage:
   driver: GeoTIFF
   crs: EPSG:3577
   tile_size:
-    x: 25000.0
-    y: 25000.0
+    x: 100000.0
+    y: 100000.0
   resolution:
     x: 25
     y: -25
@@ -45,4 +45,3 @@ measurements:
     dtype: int16
     nodata: -999
     units: '1'
-


### PR DESCRIPTION
- Jeremy identified an issue with the barest earth mosaic tile size in the product config. This change propagates that fix to the dea-config repo and our web services. 

Related Issue: https://github.com/GeoscienceAustralia/digitalearthau/issues/190

Related PR: https://github.com/GeoscienceAustralia/digitalearthau/pull/191

Looks like it doesn't affect the other dev config or prod config.