### PR TITLE
Update Fractionale_cover_percentile data type to `int16` and `nodata`…

### DIFF
--- a/dev/products/fc/fc_percentile_albers_annual.yaml
+++ b/dev/products/fc/fc_percentile_albers_annual.yaml
@@ -8,14 +8,14 @@ metadata:
   statistics:
     period: '1y'
   format:
-    name: GeoTIFF
+    name: NetCDF
   platform:
     code: LANDSAT_5,LANDSAT_7,LANDSAT_8
   instrument:
     name: TM,ETM+,OLI
 
 storage:
-  driver: GeoTIFF
+  driver: NetCDF CF
   crs: EPSG:3577
   tile_size:
     x: 100000.0
@@ -27,46 +27,46 @@ storage:
 
 measurements:
   - name: BS_PC_10
-    dtype: uint8
-    nodata: 255
+    dtype: int16
+    nodata: -1
     units: 'percent'
 
   - name: PV_PC_10
-    dtype: uint8
-    nodata: 255
+    dtype: int16
+    nodata: -1
     units: 'percent'
 
   - name: NPV_PC_10
-    dtype: uint8
-    nodata: 255
+    dtype: int16
+    nodata: -1
     units: 'percent'
 
   - name: BS_PC_50
-    dtype: uint8
-    nodata: 255
+    dtype: int16
+    nodata: -1
     units: 'percent'
 
   - name: PV_PC_50
-    dtype: uint8
-    nodata: 255
+    dtype: int16
+    nodata: -1
     units: 'percent'
 
   - name: NPV_PC_50
-    dtype: uint8
-    nodata: 255
+    dtype: int16
+    nodata: -1
     units: 'percent'
 
   - name: BS_PC_90
-    dtype: uint8
-    nodata: 255
+    dtype: int16
+    nodata: -1
     units: 'percent'
 
   - name: PV_PC_90
-    dtype: uint8
-    nodata: 255
+    dtype: int16
+    nodata: -1
     units: 'percent'
 
   - name: NPV_PC_90
-    dtype: uint8
-    nodata: 255
+    dtype: int16
+    nodata: -1
     units: 'percent'

--- a/dev/products/fc/fc_percentile_albers_annual.yaml
+++ b/dev/products/fc/fc_percentile_albers_annual.yaml
@@ -8,14 +8,14 @@ metadata:
   statistics:
     period: '1y'
   format:
-    name: NetCDF
+    name: GeoTIFF
   platform:
     code: LANDSAT_5,LANDSAT_7,LANDSAT_8
   instrument:
     name: TM,ETM+,OLI
 
 storage:
-  driver: NetCDF CF
+  driver: GeoTIFF
   crs: EPSG:3577
   tile_size:
     x: 100000.0


### PR DESCRIPTION
… to -1

Note that we might need to patch this to dev and prod cluster in AWS as its been added previously 