### PR TITLE
Remove clipping on Nidem below -2.5

### DIFF
--- a/dev/services/wms/ows/wms_cfg.py
+++ b/dev/services/wms/ows/wms_cfg.py
@@ -5163,8 +5163,7 @@ For service status information, see https://status.dea.ga.gov.au""",
                         "color_ramp": [
                             {
                                 'value': -2.51,
-                                'color': '#440154',
-                                'alpha': 0
+                                'color': '#440154'
                             },
                             {
 


### PR DESCRIPTION
RBT identified an issue with nidem clipping extreme tides, this change ensures those tides are rendered in the WMS.