### PR TITLE
Flip it and simplify the color scheme

### DIFF
--- a/dev/services/wms/thredds/wms_cfg.py
+++ b/dev/services/wms/thredds/wms_cfg.py
@@ -281,30 +281,17 @@ For service status information, see https://status.dea.ga.gov.au""",
                         "name": "nbr",
                         "title": "NBR",
                         "abstract": "The Normalized burn ratio (NBR) is used to identify burned areas. The formula is similar to a normalized difference vegetation index (NDVI), except that it uses near-infrared (NIR) and shortwave-infrared (SWIR) portions of the electromagnetic spectrum (Lopez, 1991; Key and Benson, 1995)",
-                        "index_function": lambda data: (data["nbart_nir_1"] - data["nbart_swir_3"]) / (data["nbart_nir_1"] + data["nbart_swir_3"]),
+                        "index_function": lambda data: -1 * ((data["nbart_nir_1"] - data["nbart_swir_3"]) / (data["nbart_nir_1"] + data["nbart_swir_3"])),
                         "needed_bands": ["nbart_swir_3", "nbart_nir_1"],
                         "color_ramp": [
                             {
                                 "value": -0.0,
-                                "color": "#0fc421",
+                                "color": "#f48653",
                                 "alpha": 0.0
                             },
                             {
                                 "value": 0.0,
-                                "color": "#0fc421",
-                                "alpha": 1.0
-                            },
-                            {
-                                "value": 0.088,
-                                "color": "#0fc421"
-                            },
-                            {
-                                "value": 0.22,
-                                "color": "#acefb3"
-                            },
-                            {
-                                "value": 0.32,
-                                "color": "#CEAC0E"
+                                "color": "#f48653"
                             },
                             {
                                 "value": 1.0,
@@ -738,30 +725,17 @@ For service status information, see https://status.dea.ga.gov.au""",
                         "name": "nbr",
                         "title": "NBR",
                         "abstract": "The Normalized burn ratio (NBR) is used to identify burned areas. The formula is similar to a normalized difference vegetation index (NDVI), except that it uses near-infrared (NIR) and shortwave-infrared (SWIR) portions of the electromagnetic spectrum (Lopez, 1991; Key and Benson, 1995)",
-                        "index_function": lambda data: (data["nbart_nir_1"] - data["nbart_swir_3"]) / (data["nbart_nir_1"] + data["nbart_swir_3"]),
+                        "index_function": lambda data: -1 * ((data["nbart_nir_1"] - data["nbart_swir_3"]) / (data["nbart_nir_1"] + data["nbart_swir_3"])),
                         "needed_bands": ["nbart_swir_3", "nbart_nir_1"],
                         "color_ramp": [
                             {
                                 "value": -0.0,
-                                "color": "#0fc421",
+                                "color": "#f48653",
                                 "alpha": 0.0
                             },
                             {
                                 "value": 0.0,
-                                "color": "#0fc421",
-                                "alpha": 1.0
-                            },
-                            {
-                                "value": 0.088,
-                                "color": "#0fc421"
-                            },
-                            {
-                                "value": 0.22,
-                                "color": "#acefb3"
-                            },
-                            {
-                                "value": 0.32,
-                                "color": "#CEAC0E"
+                                "color": "#f48653"
                             },
                             {
                                 "value": 1.0,
@@ -1196,30 +1170,17 @@ For service status information, see https://status.dea.ga.gov.au""",
                         "name": "nbr",
                         "title": "NBR",
                         "abstract": "The Normalized burn ratio (NBR) is used to identify burned areas. The formula is similar to a normalized difference vegetation index (NDVI), except that it uses near-infrared (NIR) and shortwave-infrared (SWIR) portions of the electromagnetic spectrum (Lopez, 1991; Key and Benson, 1995)",
-                        "index_function": lambda data: (data["nbart_nir_1"] - data["nbart_swir_3"]) / (data["nbart_nir_1"] + data["nbart_swir_3"]),
+                        "index_function": lambda data: -1 * ((data["nbart_nir_1"] - data["nbart_swir_3"]) / (data["nbart_nir_1"] + data["nbart_swir_3"])),
                         "needed_bands": ["nbart_swir_3", "nbart_nir_1"],
                         "color_ramp": [
                             {
                                 "value": -0.0,
-                                "color": "#0fc421",
+                                "color": "#f48653",
                                 "alpha": 0.0
                             },
                             {
                                 "value": 0.0,
-                                "color": "#0fc421",
-                                "alpha": 1.0
-                            },
-                            {
-                                "value": 0.088,
-                                "color": "#0fc421"
-                            },
-                            {
-                                "value": 0.22,
-                                "color": "#acefb3"
-                            },
-                            {
-                                "value": 0.32,
-                                "color": "#CEAC0E"
+                                "color": "#f48653"
                             },
                             {
                                 "value": 1.0,


### PR DESCRIPTION
Because NBR is meant to be used to compare two sets of data all of the interesting bits were <0, this PR flips it and makes all of the interesting bits red.