### PR TITLE
Updating definitions for Sentinel-2 products to handle SAFE-l1c derived products

### DIFF
--- a/dev/products/nrt/sentinel/products.yaml
+++ b/dev/products/nrt/sentinel/products.yaml
@@ -1,5 +1,38 @@
 # This file describes Sentinel 2 Data, processed through NBAR,
 # by Geoscience Australia
+
+---
+
+name: s2a_l1c_safe
+description: Sentinel-2A MSI L1C - SENTINEL-SAFE Archive
+metadata_type: eo
+
+metadata:
+    instrument:
+        name: MSI
+    platform:
+        code: Sentinel-2A
+    processing_level: Level-1C
+    product_format:
+        name: SAFE_COMPACT
+    product_type: S2MSI1C
+
+---
+
+name: s2b_l1c_safe
+description: Sentinel-2B MSI L1C - SENTINEL-SAFE Archive
+metadata_type: eo
+
+metadata:
+    instrument:
+        name: MSI
+    platform:
+        code: Sentinel-2B
+    processing_level: Level-1C
+    product_format:
+        name: SAFE_COMPACT
+    product_type: S2MSI1C
+
 ---
 
 name: s2a_l1c_aws_pds
@@ -7,12 +40,12 @@ description: Sentinel-2A MSI L1C - AWS PDS
 metadata_type: eo
 
 metadata:
-    format:
-        name: JPEG2000
     instrument:
         name: MSI
     platform:
         code: SENTINEL_2A
+    product_format:
+        name: s2_aws_pds
     processing_level: Level-1C
     product_type: level1
 
@@ -23,12 +56,12 @@ description: Sentinel-2B MSI L1C - AWS PDS
 metadata_type: eo
 
 metadata:
-    format:
-        name: JPEG2000
     instrument:
         name: MSI
     platform:
         code: SENTINEL_2B
+    product_format:
+        name: s2_aws_pds
     processing_level: Level-1C
     product_type: level1
 
@@ -40,8 +73,6 @@ description: Sentinel-2A MSI NRT - NBAR NBART and Pixel Quality
 metadata_type: eo
 
 metadata:
-    format:
-        name: GeoTiff
     instrument:
         name: MSI
     platform:
@@ -832,8 +863,6 @@ description: Sentinel-2B MSI NRT - NBAR NBART and Pixel Quality
 metadata_type: eo
 
 metadata:
-    format:
-        name: GeoTiff
     instrument:
         name: MSI
     platform:

--- a/dev/products/nrt/sentinel/products_s2msiard.yaml
+++ b/dev/products/nrt/sentinel/products_s2msiard.yaml
@@ -8,8 +8,6 @@ description: Sentinel-2A MSI ARD NRT - NBAR NBART and Pixel Quality
 metadata_type: eo
 
 metadata:
-    format:
-        name: GeoTIFF
     instrument:
         name: MSI
     platform:
@@ -800,8 +798,6 @@ description: Sentinel-2B MSI ARD NRT - NBAR NBART and Pixel Quality
 metadata_type: eo
 
 metadata:
-    format:
-        name: GeoTIFF
     instrument:
         name: MSI
     platform:


### PR DESCRIPTION
Proposed changes to allow uploading Sentinel-2 definitive products for populating the 90 backlog of the NRT service.

* Removes format: name (file format) from being a differentiating field for Sentinel-2 products
* Adds product_type as the main discriminator between aws pds and SENTINEL-SAFE level 1 formats
* Adds a product definition for the SENTINEL-2 SAFE product (in lineage)