### PR TITLE
Use https to avoid CORS errors

### DIFF
--- a/dev/terria/dea.json
+++ b/dev/terria/dea.json
@@ -1585,7 +1585,7 @@
             },
             {
                "name": "DEA Ramsar Wetlands draft polygons",
-               "url": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/Wetlands_Insight_Tool/Ramsar_exploded3.geojson",
+               "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/Wetlands_Insight_Tool/Ramsar_exploded3.geojson",
                "type": "geojson",
                "featureInfoTemplate": {
                   "template": " {{WETLAND_NA}} in {{STATE}}, feature {{FeatureID}} in the exploded Ramsar wetlands catalogue.  <p/> <figure> <img style='width: 100%' src='http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/Wetlands_Insight_Tool/{{RAMSAR_NAM}}-{{WETLAND_NA}}-{{STATE}}-{{FeatureID}}.png'/> <figcaption>Change in water, wet vegetation, green, and dead vegetation and bare soil for {{WETLAND_NA}}, established {{DESIGNATIO}}</figcaption> </figure> <p/> Download: <a href='http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/Wetlands_Insight_Tool/{{RAMSAR_NAM}}-{{WETLAND_NA}}-{{STATE}}-{{FeatureID}}.png'>chart image</a> | <a href='http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/Wetlands_Insight_Tool/{{RAMSAR_NAM}}-{{WETLAND_NA}}-{{STATE}}-{{FeatureID}}.csv'>timeseries CSV</a><p/>"


### PR DESCRIPTION
Wetland polygons not working when accessed from http://terria-cube.terria.io/ instead of https