### PR TITLE
add eks url to wms config

### DIFF
--- a/dev/services/wms/ows/wms_cfg.py
+++ b/dev/services/wms/ows/wms_cfg.py
@@ -15,6 +15,7 @@ service_cfg = {
     # Service URL.  Should a fully qualified URL
     "url": [
         "https://ows.services.dea.ga.gov.au",
+        "https://ows.services.dev.dea.ga.gov.au",
         "https://ows.services.devkube.dea.ga.gov.au",
         "https://nrt.services.dea.ga.gov.au",
         "https://geomedian.services.dea.ga.gov.au",


### PR DESCRIPTION
Our new infrastructure uses a different service url *.services.dev.dea.ga.gov.au