### PR TITLE
Add new product definition for landsat_barest_earth

### DIFF
--- a/dev/products/bare-earth/summary/be-ls-combined-product-definition.yaml
+++ b/dev/products/bare-earth/summary/be-ls-combined-product-definition.yaml
@@ -1,0 +1,48 @@
+name: landsat_barest_earth
+description: Landsat-5/Landsat-7/Landsat-8 combined Barest Earth pixel composite albers 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)
+metadata_type: eo
+metadata:
+  product_type: landsat_barest_earth
+  platform:
+    code: LANDSAT_5,LANDSAT_7,LANDSAT_8
+  format:
+    name: GeoTIFF
+  instrument:
+    name: TM,ETM+,OLI
+storage:
+  driver: GeoTIFF
+  crs: EPSG:3577
+  tile_size:
+    x: 100000.0
+    y: 100000.0
+  resolution:
+    x: 25
+    y: -25
+  dimension_order: [time, y, x]
+# possibly fix the dtype
+measurements:
+  - name: blue
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: green
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: red
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nir
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: swir1
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: swir2
+    dtype: int16
+    nodata: -999
+    units: '1'
+


### PR DESCRIPTION
Add new product definition for `landsat_barest_earth` combined product (Landsat_5, Landsat7, and Landsat_8)