### PR TITLE
Add barest earth to dev

### DIFF
--- a/dev/services/wms/ows/wms_cfg.py
+++ b/dev/services/wms/ows/wms_cfg.py
@@ -1276,7 +1276,7 @@ Mosaics are available for the following years:
                 # Included as a keyword for the layer
                 "label": "Landsat-8",
                 # Included as a keyword for the layer
-                "type": "Barest Earth",
+                "type": "albers",
                 # Included as a keyword for the layer
                 "variant": "25m",
                 "abstract": """
@@ -1820,7 +1820,7 @@ For service status information, see https://status.dea.ga.gov.au""",
                         "scale_range": [0.0, 3000.0]
                     },
                     {
-                        "name": "ndvi_ferric_iron",
+                        "name": "nd_ferric_iron",
                         "title": "Ferric Iron - (red-blue / red+blue)",
                         "abstract": "Normalised Difference Ferric Iron Index - a derived index that correlates well with the existence of Ferric Iron Content",
                         "index_function": lambda data: (data["red"] - data["blue"]) / (data["red"] + data["blue"]),
@@ -1879,8 +1879,8 @@ For service status information, see https://status.dea.ga.gov.au""",
                         ]
                     },
                     {
-                        "name": "ndvi_soil",
-                        "title": "Normalised Difference soil index - (swir1-nir / swir1+nir)",
+                        "name": "nd_soil",
+                        "title": "Normalised Difference Soil Index - (swir1-nir / swir1+nir)",
                         "abstract": "Normalised Difference Soil Index - a derived index that correlates well with the existence of bare Soil/Rock",
                         "index_function": lambda data: (data["swir1"] - data["nir"]) / (data["swir1"] + data["nir"]),
                         "needed_bands": ["nir", "swir1"],
@@ -1938,11 +1938,10 @@ For service status information, see https://status.dea.ga.gov.au""",
                         ]
                     },
                     {
-                        "name": "ndvi_clay_mica",
+                        "name": "nd_clay_mica",
                         "title": "Clay and Mica Minerals - (swir1- swir2 / swir1+swir2)",
                         "abstract": "Normalised Difference Clay and Mica Minerals Index - a derived index that correlates well with the existence of hydroxyl bearing minerals (clay and mica minerals)",
-                        "index_function": lambda data: (data["swir1"] - data["swir2"]) / (
-                                    data["swir1"] + data["swir2"]),
+                        "index_function": lambda data: (data["swir1"] - data["swir2"]) / (data["swir1"] + data["swir2"]),
                         "needed_bands": ["swir1", "swir2"],
                         "color_ramp": [
                             {

--- a/dev/terria/dea.json
+++ b/dev/terria/dea.json
@@ -370,13 +370,12 @@
                ]
             },
             {
-               "name": "Landsat-8 Barest Earth",
-
+               "name": "Barest Earth",
                "type": "group",
                "preserveOrder": true,
                "items": [
                   {
-                     "name": "Landsat-8 Barest Earth 25m Mosiac",
+                     "name": "Landsat-8 Barest Earth 25m Mosiac (Landsat-8)",
                      "type": "wms",
                      "layers": "ls8_barest_earth_mosaic",
                      "url": "https://ows.dev.dea.ga.gov.au/",
@@ -396,6 +395,28 @@
                            }
                         },
                         "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{bands.blue}}\n560,{{bands.green}}\n660,{{bands.red}}\n870,{{bands.nir}}\n1610,{{bands.swir1}}\n2200,{{bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                     }
+                  },
+                  {
+                     "name": "Landsat 30+ Barest Earth 25m Albers (Combined Landsat)",
+                     "type": "wms",
+                     "layers": "landsat_barest_earth",
+                     "url": "https://ows.dev.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dev.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "landsat_barest_earth",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureInfoTemplate": {
+                        "formats": {
+                           "lat": {
+                              "maximumFractionDigits": 5
+                           },
+                           "lon": {
+                              "maximumFractionDigits": 5
+                           }
+                        }
                      }
                   }
                ]


### PR DESCRIPTION
## Following are the changes implemented in this PR
- Correct style layer names
- Group Landsat-8 Barest Earth and Landsat 30+ Barest Earth to one group
- Add Barest Earth to Dev