### PR TITLE
Add new dea-maps catalog

### DIFF
--- a/dev/terria/dea-maps.json
+++ b/dev/terria/dea-maps.json
@@ -1,0 +1,1083 @@
+{
+   "corsDomains": [
+      "dea.ga.gov.au",
+      "gsky-dev.nci.org.au",
+      "gsky-test.nci.org.au",
+      "gsky.nci.org.au",
+      "dea-public-data-dev.s3-ap-southeast-2.amazonaws.com"
+   ],
+   "homeCamera": {
+      "north": -8,
+      "east": 158,
+      "south": -45,
+      "west": 109
+   },
+   "catalog": [
+      {
+         "name": "Satellite images",
+         "type": "group",
+         "preserveOrder": true,
+         "items": [
+            {
+               "name": "Satellite images multi-sensor - daily",
+               "type": "group",
+               "preserveOrder": true,
+               "items": [
+                  {
+                     "name": "Daily Landsat and Sentinel-2 satellite images true colour",
+                     "type": "wms",
+                     "url": "https://gsky.nci.org.au/ows/dea",
+                     "layers": "blend_sentinel2_landsat_nbart_daily_true_colour",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureTimesProperty": "data_available_for_dates"
+                  },
+                  {
+                     "name": "Daily Landsat and Sentinel-2 satellite images false colour",
+                     "type": "wms",
+                     "url": "https://gsky.nci.org.au/ows/dea",
+                     "layers": "blend_sentinel2_landsat_nbart_daily_false_colour",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureTimesProperty": "data_available_for_dates"
+                  }
+               ]
+            },
+            {
+               "name": "Satellite images 10m - daily",
+               "type": "group",
+               "preserveOrder": true,
+               "items": [
+                  {
+                     "name": "Sentinel 2 90-day expedited satellite images",
+                     "type": "group",
+                     "preserveOrder": true,
+                     "items": [
+                        {
+                           "name": "Expedited Sentinel 2 satellite images",
+                           "type": "wms",
+                           "layers": "s2_nrt_granule_nbar_t",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "s2_nrt_granule_nbar_t",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1,
+                           "featureInfoTemplate": {
+                              "formats": {
+                                 "lat": {
+                                    "maximumFractionDigits": 5
+                                 },
+                                 "lon": {
+                                    "maximumFractionDigits": 5
+                                 }
+                              },
+                              "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{bands.nbart_coastal_aerosol}}\n490,{{bands.nbart_blue}}\n560,{{bands.nbart_green}}\n670,{{bands.nbart_red}}\n710,{{bands.nbart_red_edge_1}}\n740,{{bands.nbart_red_edge_2}}\n780,{{bands.nbart_red_edge_3}}\n840,{{bands.nbart_nir_1}}\n870,{{bands.nbart_nir_2}}\n1610,{{bands.nbart_swir_2}}\n2190,{{bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                           },
+                           "featureTimesProperty": "data_available_for_dates"
+                        },
+                        {
+                           "name": "Expedited Sentinel 2A satellite images",
+                           "type": "wms",
+                           "layers": "s2a_nrt_granule_nbar_t",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "s2a_nrt_granule_nbar_t",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1,
+                           "featureInfoTemplate": {
+                              "formats": {
+                                 "lat": {
+                                    "maximumFractionDigits": 5
+                                 },
+                                 "lon": {
+                                    "maximumFractionDigits": 5
+                                 }
+                              },
+                              "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{bands.nbart_coastal_aerosol}}\n490,{{bands.nbart_blue}}\n560,{{bands.nbart_green}}\n670,{{bands.nbart_red}}\n710,{{bands.nbart_red_edge_1}}\n740,{{bands.nbart_red_edge_2}}\n780,{{bands.nbart_red_edge_3}}\n840,{{bands.nbart_nir_1}}\n870,{{bands.nbart_nir_2}}\n1610,{{bands.nbart_swir_2}}\n2190,{{bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                           },
+                           "featureTimesProperty": "data_available_for_dates"
+                        },
+                        {
+                           "name": "Expedited Sentinel 2B satellite images",
+                           "type": "wms",
+                           "layers": "s2b_nrt_granule_nbar_t",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "s2b_nrt_granule_nbar_t",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1,
+                           "featureInfoTemplate": {
+                              "formats": {
+                                 "lat": {
+                                    "maximumFractionDigits": 5
+                                 },
+                                 "lon": {
+                                    "maximumFractionDigits": 5
+                                 }
+                              },
+                              "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{bands.nbart_coastal_aerosol}}\n490,{{bands.nbart_blue}}\n560,{{bands.nbart_green}}\n670,{{bands.nbart_red}}\n710,{{bands.nbart_red_edge_1}}\n740,{{bands.nbart_red_edge_2}}\n780,{{bands.nbart_red_edge_3}}\n840,{{bands.nbart_nir_1}}\n870,{{bands.nbart_nir_2}}\n1610,{{bands.nbart_swir_2}}\n2190,{{bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                           },
+                           "featureTimesProperty": "data_available_for_dates"
+                        }
+                     ]
+                  },
+                  {
+                     "name": "Sentinel 2 satellite imagery archive",
+                     "type": "group",
+                     "preserveOrder": true,
+                     "items": [
+                        {
+                           "name": "Sentinel 2 satellite images",
+                           "type": "wms",
+                           "layers": "s2_ard_granule_nbar_t",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "s2_ard_granule_nbar_t",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1,
+                           "featureInfoTemplate": {
+                              "formats": {
+                                 "lat": {
+                                    "maximumFractionDigits": 5
+                                 },
+                                 "lon": {
+                                    "maximumFractionDigits": 5
+                                 }
+                              },
+                              "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{bands.nbart_coastal_aerosol}}\n490,{{bands.nbart_blue}}\n560,{{bands.nbart_green}}\n670,{{bands.nbart_red}}\n710,{{bands.nbart_red_edge_1}}\n740,{{bands.nbart_red_edge_2}}\n780,{{bands.nbart_red_edge_3}}\n840,{{bands.nbart_nir_1}}\n870,{{bands.nbart_nir_2}}\n1610,{{bands.nbart_swir_2}}\n2190,{{bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                           },
+                           "featureTimesProperty": "data_available_for_dates"
+                        },
+                        {
+                           "name": "Sentinel 2a satellite images",
+                           "type": "wms",
+                           "layers": "s2a_ard_granule_nbar_t",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "s2a_ard_granule_nbar_t",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1,
+                           "featureInfoTemplate": {
+                              "formats": {
+                                 "lat": {
+                                    "maximumFractionDigits": 5
+                                 },
+                                 "lon": {
+                                    "maximumFractionDigits": 5
+                                 }
+                              },
+                              "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{bands.nbart_coastal_aerosol}}\n490,{{bands.nbart_blue}}\n560,{{bands.nbart_green}}\n670,{{bands.nbart_red}}\n710,{{bands.nbart_red_edge_1}}\n740,{{bands.nbart_red_edge_2}}\n780,{{bands.nbart_red_edge_3}}\n840,{{bands.nbart_nir_1}}\n870,{{bands.nbart_nir_2}}\n1610,{{bands.nbart_swir_2}}\n2190,{{bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                           },
+                           "featureTimesProperty": "data_available_for_dates"
+                        },
+                        {
+                           "name": "Sentinel 2b satellite images",
+                           "type": "wms",
+                           "layers": "s2b_ard_granule_nbar_t",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "s2b_ard_granule_nbar_t",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1,
+                           "featureInfoTemplate": {
+                              "formats": {
+                                 "lat": {
+                                    "maximumFractionDigits": 5
+                                 },
+                                 "lon": {
+                                    "maximumFractionDigits": 5
+                                 }
+                              },
+                              "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{bands.nbart_coastal_aerosol}}\n490,{{bands.nbart_blue}}\n560,{{bands.nbart_green}}\n670,{{bands.nbart_red}}\n710,{{bands.nbart_red_edge_1}}\n740,{{bands.nbart_red_edge_2}}\n780,{{bands.nbart_red_edge_3}}\n840,{{bands.nbart_nir_1}}\n870,{{bands.nbart_nir_2}}\n1610,{{bands.nbart_swir_2}}\n2190,{{bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                           },
+                           "featureTimesProperty": "data_available_for_dates"
+                        }
+                     ]
+                  }
+               ]
+            },
+            {
+               "name": "Satellite images 25m - daily",
+               "type": "group",
+               "preserveOrder": true,
+               "items": [
+                  {
+                     "name": "Daily Landsat 8 satellite images",
+                     "type": "wms",
+                     "layers": "landsat8_nbart_daily",
+                     "url": "https://gsky.nci.org.au/ows/dea",
+                     "linkedWcsUrl": "https://gsky.nci.org.au/ows/dea",
+                     "linkedWcsCoverage": "landsat8_nbart_daily",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureInfoTemplate": {
+                        "formats": {
+                           "lat": {
+                              "maximumFractionDigits": 5
+                           },
+                           "lon": {
+                              "maximumFractionDigits": 5
+                           }
+                        },
+                        "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{bands.blue}}\n560,{{bands.green}}\n660,{{bands.red}}\n870,{{bands.nir}}\n1610,{{bands.swir1}}\n2200,{{bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                     }
+                  },
+                  {
+                     "name": "Daily Landsat 7 satellite images",
+                     "type": "wms",
+                     "layers": "landsat7_nbart_daily",
+                     "url": "https://gsky.nci.org.au/ows/dea",
+                     "linkedWcsUrl": "https://gsky.nci.org.au/ows/dea",
+                     "linkedWcsCoverage": "landsat7_nbart_daily",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureInfoTemplate": {
+                        "formats": {
+                           "lat": {
+                              "maximumFractionDigits": 5
+                           },
+                           "lon": {
+                              "maximumFractionDigits": 5
+                           }
+                        },
+                        "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{bands.blue}}\n560,{{bands.green}}\n660,{{bands.red}}\n840,{{bands.nir}}\n1650,{{bands.swir1}}\n2220,{{bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                     }
+                  },
+                  {
+                     "name": "Daily Landsat 5 satellite images",
+                     "type": "wms",
+                     "layers": "landsat5_nbart_daily",
+                     "url": "https://gsky.nci.org.au/ows/dea",
+                     "linkedWcsUrl": "https://gsky.nci.org.au/ows/dea",
+                     "linkedWcsCoverage": "landsat5_nbart_daily",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureInfoTemplate": {
+                        "formats": {
+                           "lat": {
+                              "maximumFractionDigits": 5
+                           },
+                           "lon": {
+                              "maximumFractionDigits": 5
+                           }
+                        },
+                        "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{bands.blue}}\n560,{{bands.green}}\n660,{{bands.red}}\n840,{{bands.nir}}\n1650,{{bands.swir1}}\n2220,{{bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                     }
+                  }
+               ]
+            },
+            {
+               "name": "Satellite images 25m - 16 days",
+               "type": "group",
+               "preserveOrder": true,
+               "items": [
+                  {
+                     "name": "Landsat 8 satellite 16-day composite",
+                     "type": "wms",
+                     "layers": "landsat8_nbart_16day",
+                     "url": "https://gsky.nci.org.au/ows/dea",
+                     "linkedWcsUrl": "https://gsky.nci.org.au/ows/dea",
+                     "linkedWcsCoverage": "landsat8_nbart_16day",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureInfoTemplate": {
+                        "formats": {
+                           "lat": {
+                              "maximumFractionDigits": 5
+                           },
+                           "lon": {
+                              "maximumFractionDigits": 5
+                           }
+                        },
+                        "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{bands.blue}}\n560,{{bands.green}}\n660,{{bands.red}}\n870,{{bands.nir}}\n1610,{{bands.swir1}}\n2200,{{bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                     }
+                  },
+                  {
+                     "name": "Landsat 7 satellite 16-day composite",
+                     "type": "wms",
+                     "layers": "landsat7_nbart_16day",
+                     "url": "https://gsky.nci.org.au/ows/dea",
+                     "linkedWcsUrl": "https://gsky.nci.org.au/ows/dea",
+                     "linkedWcsCoverage": "landsat7_nbart_16day",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureInfoTemplate": {
+                        "formats": {
+                           "lat": {
+                              "maximumFractionDigits": 5
+                           },
+                           "lon": {
+                              "maximumFractionDigits": 5
+                           }
+                        },
+                        "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{bands.blue}}\n560,{{bands.green}}\n660,{{bands.red}}\n840,{{bands.nir}}\n1650,{{bands.swir1}}\n2220,{{bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                     }
+                  },
+                  {
+                     "name": "Landsat 5 satellite 16-day composite",
+                     "type": "wms",
+                     "layers": "landsat5_nbart_16day",
+                     "url": "https://gsky.nci.org.au/ows/dea",
+                     "linkedWcsUrl": "https://gsky.nci.org.au/ows/dea",
+                     "linkedWcsCoverage": "landsat5_nbart_16day",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureInfoTemplate": {
+                        "formats": {
+                           "lat": {
+                              "maximumFractionDigits": 5
+                           },
+                           "lon": {
+                              "maximumFractionDigits": 5
+                           }
+                        },
+                        "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{bands.blue}}\n560,{{bands.green}}\n660,{{bands.red}}\n840,{{bands.nir}}\n1650,{{bands.swir1}}\n2220,{{bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                     }
+                  }
+               ]
+            },
+            {
+               "name": "Satellite images 25m - annual",
+               "type": "group",
+               "preserveOrder": true,
+               "items": [
+                  {
+                     "name": "Yearly average Landsat 8 satellite images",
+                     "type": "wms",
+                     "layers": "ls8_nbart_geomedian_annual",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "ls8_nbart_geomedian_annual",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureInfoTemplate": {
+                        "formats": {
+                           "lat": {
+                              "maximumFractionDigits": 5
+                           },
+                           "lon": {
+                              "maximumFractionDigits": 5
+                           }
+                        },
+                        "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{bands.blue}}\n560,{{bands.green}}\n660,{{bands.red}}\n870,{{bands.nir}}\n1610,{{bands.swir1}}\n2200,{{bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                     }
+                  },
+                  {
+                     "name": "Yearly average Landsat 7 satellite images",
+                     "type": "wms",
+                     "layers": "ls7_nbart_geomedian_annual",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "ls7_nbart_geomedian_annual",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureInfoTemplate": {
+                        "formats": {
+                           "lat": {
+                              "maximumFractionDigits": 5
+                           },
+                           "lon": {
+                              "maximumFractionDigits": 5
+                           }
+                        },
+                        "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{bands.blue}}\n560,{{bands.green}}\n660,{{bands.red}}\n840,{{bands.nir}}\n1650,{{bands.swir1}}\n2220,{{bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                     }
+                  },
+                  {
+                     "name": "Yearly average Landsat 5 satellite images",
+                     "type": "wms",
+                     "layers": "ls5_nbart_geomedian_annual",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "ls5_nbart_geomedian_annual",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureInfoTemplate": {
+                        "formats": {
+                           "lat": {
+                              "maximumFractionDigits": 5
+                           },
+                           "lon": {
+                              "maximumFractionDigits": 5
+                           }
+                        },
+                        "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{bands.blue}}\n560,{{bands.green}}\n660,{{bands.red}}\n840,{{bands.nir}}\n1650,{{bands.swir1}}\n2220,{{bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                     }
+                  }
+               ]
+            },
+            {
+               "name": "Satellite images 25m - Barest Earth",
+               "type": "group",
+               "preserveOrder": true,
+               "items": [
+                  {
+                     "name": "Barest Earth Landsat 8 satellite images",
+                     "type": "wms",
+                     "layers": "ls8_barest_earth_mosaic",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "ls8_barest_earth_mosaic",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureInfoTemplate": {
+                        "formats": {
+                           "lat": {
+                              "maximumFractionDigits": 5
+                           },
+                           "lon": {
+                              "maximumFractionDigits": 5
+                           }
+                        },
+                        "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{bands.blue}}\n560,{{bands.green}}\n660,{{bands.red}}\n870,{{bands.nir}}\n1610,{{bands.swir1}}\n2200,{{bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
+                     }
+                  }
+               ]
+            }
+         ]
+      },
+      {
+         "name": "Surface Water",
+         "type": "group",
+         "preserveOrder": true,
+         "items": [
+             {
+               "name": "Waterbody Area Mapping and Monitoring",
+               "type": "wms",
+               "layers": "water_bodies",
+               "url": "https://ows.dea.ga.gov.au/",
+               "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+               "linkedWcsCoverage": "water_bodies",
+               "ignoreUnknownTileErrors": true,
+               "opacity": 1,
+               "featureInfoTemplate": {
+                  "formats": {
+                     "lat": {
+                        "maximumFractionDigits": 5
+                     },
+                     "lon": {
+                        "maximumFractionDigits": 5
+                     }
+                  },
+                  "template": "<div style='width:600px'><h3>Water Body Identifier: {{bands.dam_id}}</h3><br/><chart id='{{bands.dam_id}}' title='Water Body {{bands.dam_id}}' preview-x-label='Water Observed' sources='{{#terria.urlEncode}}{{timeseries}}{{/terria.urlEncode}}'  column-names='Time,Percentage,Pixel Count' column-units='Date,%,#'></chart></div>"
+               }
+            },
+            {
+               "name": "Water Observations from Space",
+               "type": "group",
+               "preserveOrder": true,
+               "items": [
+                  {
+                     "name": "Daily water observations",
+                     "type": "wms",
+                     "layers": "wofs_albers",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "wofs_albers",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureTimesProperty": "data_available_for_dates"
+                  },
+                  {
+                     "name": "April-October water observations",
+                     "type": "wms",
+                     "layers": "wofs_apr_oct_summary_statistics",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "wofs_apr_oct_summary_statistics",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1
+                  },
+                  {
+                     "name": "November-March water observations",
+                     "type": "wms",
+                     "layers": "wofs_nov_mar_summary_statistics",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "wofs_nov_mar_summary_statistics",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1
+                  },
+                  {
+                     "name": "Annual water observations",
+                     "type": "wms",
+                     "layers": "wofs_annual_summary_statistics",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "wofs_annual_summary_statistics",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1
+                  },
+                  {
+                     "name": "All water observations",
+                     "type": "wms",
+                     "layers": "wofs_filtered_summary",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "wofs_filtered_summary",
+                     "ignoreUnknownTileErrors": true,
+                     "opacity": 1
+                  },
+                  {
+                     "name": "April-October water observations source data",
+                     "type": "group",
+                     "preserveOrder": true,
+                     "items": [
+                        {
+                           "name": "April-October clear observations",
+                           "type": "wms",
+                           "layers": "wofs_apr_oct_summary_clear",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "wofs_apr_oct_summary_clear",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1
+                        },
+                        {
+                           "name": "April-October wet observations",
+                           "type": "wms",
+                           "layers": "wofs_apr_oct_summary_wet",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "wofs_apr_oct_summary_wet",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1
+                        }
+                     ]
+                  },
+                  {
+                     "name": "November-March water observations source data",
+                     "type": "group",
+                     "preserveOrder": true,
+                     "items": [
+                        {
+                           "name": "November-March clear observations",
+                           "type": "wms",
+                           "layers": "wofs_nov_mar_summary_clear",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "wofs_nov_mar_summary_clear",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1
+                        },
+                        {
+                           "name": "November-March wet observations",
+                           "type": "wms",
+                           "layers": "wofs_nov_mar_summary_wet",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "wofs_nov_mar_summary_wet",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1
+                        }
+                     ]
+                  },
+                  {
+                     "name": "Annual water observations source data",
+                     "type": "group",
+                     "preserveOrder": true,
+                     "items": [
+                        {
+                           "name": "Annual clear observations",
+                           "type": "wms",
+                           "layers": "wofs_annual_summary_clear",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "wofs_annual_summary_clear",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1
+                        },
+                        {
+                           "name": "Annual wet observations",
+                           "type": "wms",
+                           "layers": "wofs_annual_summary_wet",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "wofs_annual_summary_wet",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1
+                        }
+                     ]
+                  },
+                  {
+                     "name": "All water observations combined source data",
+                     "type": "group",
+                     "preserveOrder": true,
+                     "items": [
+                        {
+                           "name": "All clear observations",
+                           "type": "wms",
+                           "layers": "wofs_summary_clear",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "wofs_summary_clear",
+                           "ignoreUnknownTileErrors": true,
+                           "opacity": 1
+                        },
+                        {
+                           "name": "All wet observations",
+                           "type": "wms",
+                           "layers": "wofs_summary_wet",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "wofs_summary_wet",
+                           "ignoreUnknownTileErrors": true,
+                           "opacity": 1
+                        },
+                        {
+                           "name": "Unfiltered summary of all water observations",
+                           "type": "wms",
+                           "layers": "Water Observations from Space Statistics",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "Water Observations from Space Statistics",
+                           "ignoreUnknownTileErrors": true,
+                           "opacity": 1
+                        },
+                        {
+                           "name": "Water observations confidence",
+                           "type": "wms",
+                           "layers": "wofs_filtered_summary_confidence",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "wofs_filtered_summary_confidence",
+                           "ignoreUnknownTileErrors": true,
+                           "opacity": 1
+                        }
+                     ]
+                  }
+               ]
+            }
+         ]
+      },
+      {
+         "name": "Vegetation",
+         "type": "group",
+         "preserveOrder": true,
+         "items": [
+            {
+               "name": "Mangrove Canopy Cover",
+               "type": "wms",
+               "layers": "mangrove_cover_v2_0_2",
+               "url": "https://ows.dea.ga.gov.au/",
+               "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+               "linkedWcsCoverage": "mangrove_cover_v2_0_2",
+               "ignoreUnknownTileErrors": true,
+               "chartType": "momentPoints",
+               "chartColor": "white",
+               "opacity": 1
+            },
+            {
+               "name": "Fractional Cover",
+               "type": "group",
+               "preserveOrder": true,
+               "items": [
+                  {
+                     "name": "Daily Fractional Cover observations",
+                     "type": "wms",
+                     "layers": "fc_albers_combined",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "fc_albers_combined",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1,
+                     "featureTimesProperty": "data_available_for_dates"
+                  },
+                  {
+                     "name": "Seasonal Fractional Cover",
+                     "type": "wms",
+                     "layers": "fcp_seasonal_rgb",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "fcp_seasonal_rgb",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1
+                  },
+                  {
+                     "name": "Annual Fractional Cover",
+                     "type": "wms",
+                     "layers": "fcp_rgb",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "fcp_rgb",
+                     "ignoreUnknownTileErrors": true,
+                     "chartType": "momentPoints",
+                     "chartColor": "white",
+                     "opacity": 1
+                  },
+                  {
+                     "name": "Daily Fractional Cover observations by sensor",
+                     "type": "group",
+                     "preserveOrder": true,
+                     "items": [
+                        {
+                           "name": "Daily Landsat 8 Fractional Cover observations",
+                           "type": "wms",
+                           "layers": "ls8_fc_albers",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "ls8_fc_albers",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1,
+                           "featureTimesProperty": "data_available_for_dates"
+                        },
+                        {
+                           "name": "Daily Landsat 7 Fractional Cover observations",
+                           "type": "wms",
+                           "layers": "ls7_fc_albers",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "ls7_fc_albers",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1,
+                           "featureTimesProperty": "data_available_for_dates"
+                        },
+                        {
+                           "name": "Daily Landsat 5 Fractional Cover observations",
+                           "type": "wms",
+                           "layers": "ls5_fc_albers",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "ls5_fc_albers",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1,
+                           "featureTimesProperty": "data_available_for_dates"
+                        }
+                     ]
+                  },
+                  {
+                     "name": "Seasonal Fractional Cover summaries",
+                     "type": "group",
+                     "preserveOrder": true,
+                     "items": [
+                        {
+                           "name": "Seasonal Green Vegetation",
+                           "type": "wms",
+                           "layers": "fcp_seasonal_green_veg",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "fcp_seasonal_green_veg",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1
+                        },
+                        {
+                           "name": "Seasonal Non-Green Vegetation",
+                           "type": "wms",
+                           "layers": "fcp_seasonal_non_green_veg",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "fcp_seasonal_non_green_veg",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1
+                        },
+                        {
+                           "name": "Seasonal Bare Ground",
+                           "type": "wms",
+                           "layers": "fcp_seasonal_bare_ground",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "fcp_seasonal_bare_ground",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1
+                        }
+                     ]
+                  },
+                  {
+                     "name": "Annual Fractional Cover summaries",
+                     "type": "group",
+                     "preserveOrder": true,
+                     "items": [
+                        {
+                           "name": "Annual Green Vegetation",
+                           "type": "wms",
+                           "layers": "fcp_green_veg",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "fcp_green_veg",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1
+                        },
+                        {
+                           "name": "Annual Non-Green Vegetation",
+                           "type": "wms",
+                           "layers": "fcp_non_green_veg",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "fcp_non_green_veg",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1
+                        },
+                        {
+                           "name": "Annual Bare Ground",
+                           "type": "wms",
+                           "layers": "fcp_bare_ground",
+                           "url": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                           "linkedWcsCoverage": "fcp_bare_ground",
+                           "ignoreUnknownTileErrors": true,
+                           "chartType": "momentPoints",
+                           "chartColor": "white",
+                           "opacity": 1
+                        }
+                     ]
+                  }
+               ]
+            }
+         ]
+      },
+      {
+         "name": "Coastal",
+         "type": "group",
+         "preserveOrder": true,
+         "items": [
+            {
+               "name": "National Intertidal Digital Elevation Model",
+               "type": "wms",
+               "layers": "NIDEM",
+               "url": "https://ows.dea.ga.gov.au/",
+               "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+               "linkedWcsCoverage": "NIDEM",
+               "ignoreUnknownTileErrors": true,
+               "opacity": 1
+            },
+            {
+               "name": "Intertidal extent model",
+               "type": "group",
+               "preserveOrder": true,
+               "items": [
+                   {
+                     "name": "Intertidal Extent",
+                     "type": "wms",
+                     "layers": "ITEM_V2.0.0",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "ITEM_V2.0.0",
+                     "ignoreUnknownTileErrors": true,
+                     "opacity": 1
+                  },
+                  {
+                     "name": "Intertidal Extent Polygons data access",
+                     "type": "geojson",
+                     "url": "https://data.dea.ga.gov.au/ITEM_V2/Itemv2.geojson",
+                     "featureInfoTemplate": {
+                          "template": "The <b>ITEM v2.0 relative model</b> displays the modelled extents of the exposed intertidal zone, at percentile intervals of the observed tidal range (OTR), derived from Landsat imagery acquired between 1986 and 2016. <p/> The full tidal range at this location is {{LMT}} to {{HMT}} metres relative to mean sea level (MSL), and the OTR at this location is between {{LOT}} and {{HOT}} relative to MSL. <p/> The <b>ITEM v2.0 confidence layer</b> displays the standard deviation of the water index values (NDWI) derived across the tidal intervals used in generating the core ITEM relative product. <p/> High values indicate regions where inundation patterns are not driven by tidal influences. This can be a result of change (shoreline, geomorphic, anthropogenic), or caused by errors in the underlying tidal model. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/ITEM_Intervals/ITEM_REL_{{ID}}_{{lon}}_{{lat}}.jpg'/> <figcaption>Coloured bars corresponding to the legend highlight the observations (black dots) and tidal range used to generate each ITEM interval, compared to the full modelled tidal range (light grey) at this location</figcaption> </figure> <p/> Download the GeoTIFF products for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/ITEM/ITEM_2_0/geotiff/ITEM_REL_{{ID}}_{{lon}}_{{lat}}.tif'>ITEM_REL_{{ID}}_{{lon}}_{{lat}}.tif</a> <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/ITEM/ITEM_2_0/geotiff/ITEM_STD_{{ID}}_{{lon}}_{{lat}}.tif'>ITEM_STD_{{ID}}_{{lon}}_{{lat}}.tif</a>",
+                          "formats": {
+                            "lat": {
+                              "type": "number",
+                              "minimumFractionDigits": 2
+                            },
+                            "lon": {
+                              "type": "number",
+                              "minimumFractionDigits": 2
+                            }
+                          }
+                     },
+                     "info": [
+                        {
+                         "name": "Abstract",
+                         "content": "The Intertidal Extents Model (ITEM v2.0) product analyses GA’s historic archive of satellite imagery to derive a model of the spatial extents of the intertidal zone throughout the tidal cycle. The model can assist in understanding the relative elevation profile of the intertidal zone, delineating exposed areas at differing tidal heights and stages. <p/> The product differs from previous methods used to map the intertidal zone which have been predominately focused on analysing a small number of individual satellite images per location (e.g Ryu et al., 2002; Murray et al., 2012). By utilising a full 30 year time series of observations and a global tidal model (Egbert and Erofeeva, 2002), the methodology enables us to overcome the requirement for clear, high quality observations acquired concurrent to the time of high and low tide."
+                        },
+                        {
+                         "name": "Overview",
+                         "content": "The Intertidal Extents Model product is a national scale gridded dataset characterising the spatial extents of the exposed intertidal zone, at intervals of the observed tidal range (Sagar et al. 2017). The current version (2.0) utilises all Landsat observations (5, 7, and 8) for Australian coastal regions (excluding off-shore Territories) between 1986 and 2016 (inclusive). <p/> ITEM v2.0 has implemented an improved tidal modelling framework (see Sagar et al. 2018) over that utilised in ITEM v1.0. The expanded Landsat archive within the Digital Earth Australia (DEA) has also enabled the model extent to be increased to cover a number of offshore reefs, including the full Great Barrier Reef and southern sections of the Torres Strait Islands. The DEA archive and new tidal modelling framework has improved the coverage and quality of the ITEM v2.0 relative extents model, particularly in regions where AGDC cell boundaries in ITEM v1.0 produced discontinuities or the imposed v1.0 cell structure resulted in poor quality tidal modelling (see Sagar et al. 2017). <p/> Examples of regions in ITEM v2.0 where these significant improvements have been noted include: <ul> <li>Dampier Peninsula and King Sound, WA. Improved modelling within King Sound has removed the discontinuities seen at cell boundaries in ITEM v1.0, and expanded the extent of intertidal region being mapped. </li> <li>Tiwi Islands, Coburg Peninsula and Croker Island, NT. Poor spatial representation of the regions tidal regimes in ITEM v1.0 has been improved in v2.0 resulting in extensive onshore reefs and mudflats now being mapped. </li> <li>The full Great Barrier Reef has been mapped, detailing reef structures which expose at low tide. Algorithm amendments have reduced the false positive exposed surface detections resulting from glint and sun glitter. </li> <li>Broad Sound, QLD. Improved tidal modelling has resulted in a smoother intertidal extent map, and a greatly improved confidence layer value for the region. </li> <li>Improvements in the coverage of the DEA archive has allowed many regions unresolved in ITEM v1.0 and showing as 'no data' to be modelled successfully in ITEM 2.0. For example, Mornington Island, QLD, Eastern sections of Fraser Island, QLD and peninsulas in Bowling Green Bay National Park near Townsville, QLD</li> </ul>"
+                        },
+                        {
+                         "name": "Accuracy and limitations",
+                         "content": "Due the sun-synchronous nature of the various Landsat sensor observations; it is unlikely that the full physical extents of the tidal range in any cell will be observed. Hence, terminology has been adopted for the product to reflect the highest modelled tide observed in a given cell (HOT) and the lowest modelled tide observed (LOT) (see Sagar et al. 2017). These measures are relative to Mean Sea Level, and have no consistent relationship to Lowest (LAT) and Highest Astronomical Tide (HAT). <p/> The inclusion of the lowest (LMT) and highest (HMT) modelled tide values for each tidal polygon indicates the highest and lowest tides modelled for that location across the full time series by the OTPS model. The relative difference between the LOT and LMT (and HOT and HMT) heights gives an indication of the extent of the tidal range represented in the Relative Extents Model. <p/> As in ITEM v1.0, v2.0 contains some false positive land detection in open ocean regions. These are a function of the lack of data at the extremes of the observed tidal range, and features like glint and undetected cloud in these data poor regions/intervals. <p/> Methods to isolate and remove these features are in development for future versions. Issues in the DEA archive and data noise in the Esperance, WA region off Cape Le Grande and Cape Arid (Polygons 236,201,301) has resulted in significant artefacts in the model, and use of the model in this area is not recommended. <p/> The Confidence layer is designed to assess the reliability of the Relative Extent Model. Within each tidal range percentile interval, the pixel-based standard deviation of the NDWI values for all observations in the interval subset is calculated. The average standard deviation across all tidal range intervals is then calculated and retained as a quality indicator in this product layer. <p/> The Confidence Layer reflects the pixel based consistency of the NDWI values within each subset of observations, based on the tidal range. Higher standard deviation values indicate water classification changes not based on the tidal cycle, and hence lower confidence in the extent model. <p/> Possible drivers of these changes include: <ol> <li>Inadequacies of the tidal model, due perhaps to complex coastal bathymetry or estuarine structures not captured in the model. These effects have been reduced in ITEM v2.0 compared to previous versions, through the use of an improved tidal modelling framework </li> <li>Change in the structure and exposure of water/non-water features NOT driven by tidal variation. For example, movement of sand banks in estuaries, construction of man-made features (ports etc.).</li> <li>Terrestrial/Inland water features not influenced by the tidal cycle.</li> </ol>"
+                        },
+                        {
+                         "name": "File naming",
+                         "content": "<h4>THE RELATIVE EXTENTS MODEL v2.0</h4> ITEM_REL_&lt;TIDAL POLYGON NUMBER&gt;_&lt;LONGITUDE&gt;_&lt;LATITUDE&gt; <p/> TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <p/> LONGITUDE is the longitude of the centroid of the tidal polygon <p/> LATITUDE is the latitude of the centroid of the tidal polygon <h4>THE CONFIDENCE LAYER v2.0</h4> ITEM_STD_&lt;TIDAL POLYGON NUMBER&gt;_&lt;LONGITUDE&gt;_&lt;LATITUDE&gt; <p/> TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <p/> LONGITUDE is the longitude of the centroid of the tidal polygon <p/> LATITUDE is the latitude of the centroid of the tidal polygon <p/> The index of downloadable GeoTIFFs can be found here: <p/> <a href='http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalogs/fk4/item_2_0.xml'>http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalogs/fk4/item_2_0.xml</a>"
+                        },
+                        {
+                         "name": "References",
+                         "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmos. Oceanic Technol. 19, 183–204. <p/> Murray, N.J., Phinn, S.R., Clemens, R.S., Roelfsema, C.M., Fuller, R.A., 2012. Continental Scale Mapping of Tidal Flats across East Asia Using the Landsat Archive. Remote Sensing 4, 3417–3426. <p/> Ryu, J.-H., Won, J.-S., Min, K.D., 2002. Waterline extraction from Landsat TM data in a tidal flat: A case study in Gomso Bay, Korea. Remote Sensing of Environment 83, 442–456. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sensing of Environment 195, 153–169. <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
+                        }
+                     ]
+                  },
+                  {
+                     "name": "Intertidal Extent Confidence",
+                     "type": "wms",
+                     "layers": "ITEM_V2.0.0_Conf",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "ITEM_V2.0.0_Conf",
+                     "ignoreUnknownTileErrors": true,
+                     "opacity": 1
+                  }
+               ]
+            },
+            {
+               "name": "Low tide satelitte images",
+               "type": "group",
+               "preserveOrder": true,
+               "items": [
+                  {
+                     "name": "Low tide Landsat satellite images",
+                     "type": "wms",
+                     "layers": "low_tide_composite",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "low_tide_composite",
+                     "ignoreUnknownTileErrors": true,
+                     "opacity": 1
+                  },
+                  {
+                     "name": "Low Tide Polygons for data access",
+                     "type": "geojson",
+                     "url": "https://data.dea.ga.gov.au/LHTC_Tides/low_composite_20.geojson",
+                     "featureInfoTemplate": {
+                        "template" : "The tidal range at this location is {{modelLow}} to {{modelHigh}} meters relative to mean sea level (MSL). <p/> The low tide composite at this location was generated from imagery acquired in the lowest 20% of the observed tidal range which is between {{LIT}} and {{HIT}} meters relative to MSL, during the period of time of {{date_range}}. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/LHTC_Tides/COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.jpg'/> <figcaption>Observations used to generate the composite (black dots), in relation to the full modelled tidal range (blue) and complete archive (white dots) at this location</figcaption> </figure> <p/> Download the GeoTIFF for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif'>COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif</a>"
+                     },
+                     "info": [
+                        {
+                           "name": "Abstract",
+                           "content": "High Tide and Low Tide Composites 2.0.0 <p/> The High and Low Tide Composites product is composed of two surface reflectance composite mosaics of Landsat TM and ETM+ (Landsat 5 and Landsat 7 respectively) and OLI (Landsat 8) surface reflectance data (Li et al., 2012). These products have been produced using Digital Earth Australia (DEA). The two mosaics allow cloud free and noise reduced visualisation of the shallow water and inter-tidal coastal regions of Australia, as observed at high and low tide respectively (Sagar et al. 2018). <p/> The composites are generated utilising the geomedian approach of Roberts et al (2017) to ensure a valid surface reflectance spectra suitable for uses such as habitat mapping. The time range used for composite generation in each polygon of the mosaic is tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The concepts of the Observed Tidal Range (OTR), and Highest and Lowest Observed Tide (HOT, LOT) are discussed and described fully in Sagar et al. (2017) and the product description for the ITEM v 1.0 product (Geoscience Australia, 2016)."
+                        },
+                        {
+                           "name": "Overview",
+                           "content": "Inter-tidal zones are difficult regions to characterise due to the dynamic nature of the tide. They are highly changeable environments, subject to forcings from the land, sea and atmosphere and yet they form critical habitats for a wide range of organisms from birds to fish and sea grass. By harnessing the long archive of satellite imagery over Australia's coastal zones in the DEA and pairing the images with regional tidal modelling, the archive can be sorted by tide height rather than date, enabling the inter-tidal zone to be viewed at any stage of the tide regime. <p/> The High Low Tide Composites (HLTC_25) product is composed of two mosaics, distinguished by tide height, representing a composite image of the synthetic geomedian surface reflectance from Landsats 5 TM, Landsat 7 ETM+ and Landsat 8 OLI NBAR data (Li et al., 2012; Roberts et al., 2017). Oregon State Tidal Prediction (OTPS) software (Egbert and Erofeeva, 2002, 2010) was used to generate tide heights, relative to mean sea level, for the Australian continental coastline, split into 306 distinct tidal regions. These time and date stamped tidal values were then attributed to all coastal tile observations for their time of acquisition, creating a range of observed tide heights for the Australian coastline. The two mosaics in HLTC_25 are composited from the highest and lowest 20 % of observed tide in the ensemble and are termed HOT and LOT respectively. A geomedian composite for each Landsat band is calculated from the tiles in each ensemble subset to produce the respective HOT and LOT composites. Note that Landsat 7 ETM+ observations are excluded after May 2003 due to a large number of data artefacts. <p/> The time range used for composite generation in each of the 306 polygons of the mosaics are tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The maximum epoch for which the products are calculated is between 1995-2017, although this varies due to data resolution and observation quality. The product also includes a count of clear observations per pixel for both mosaics and attribute summaries per polygon that include the date range, the highest and lowest modeled astronomical tide as well as the highest and lowest observed tide for that time range, the total observation count and the maximum count of observations for any one pixel in the polygon, the polygon ID number (from 1 to 306), the polygon centroid in longitude and latitude and the count of tide stages attributed to every observation used in that polygon of the mosaic. For the count of tidal stage observations, e = ebbing tide, f = flowing tide, ph = peak high tide and pl = peak low tide. The tide stages were calculated by comparison to the modeled tide data for 15 minutes either side of the observation to determine the ebb, flow or peak movement of the tide. <p/> Observations are filtered to remove poor quality observations including cloud, cloud shadow and band saturation (of any band)."
+                        },
+                        {
+                           "name": "Accuracy and limitations",
+                           "content": "The accuracy of the tide height data is limited by the accuracy of the OTPS model. Tidal modelling on self-similar coastal polygons was performed to minimise regional uncertainty. <p/> Accuracies and limitations related to geomedian compositing of observations are discussed in Roberts et al (2017). <p/> Users should beware of seasonal and diurnal effects in the imagery, especially in the north east of Australia where the footprint of the highest and lowest astronomical tides are large. Consequently, where image acquisition misses the highest astronomical tide, for example, pooling effects of water are still visible in the landscape in lowest observed tidal composite imagery. <p/> This product has been rendered in both true colour and false colour. Validation and interpretation of surface features has not been attempted here. Interpretation of surface features is at the users own discretion."
+                        },
+                        {
+                           "name": "File naming",
+                           "content": "`<COUNT OR COMPOSITE>_<HIGH OR LOW>_<TIDAL POLYGON NUMBER>_<LONGITUDE>_<LATITUDE>_<START DATE>_<END DATE>_<PERCENTILE TIDE RANGE>` <p/> COUNT OR COMPOSITE refers to whether pixels contain composite observation values or the count of observations at that pixel location <br/>HIGH OR LOW refers to whether the content relates to High Tide values or Low Tide values <br/>TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <br/>LONGITUDE is the longitude of the centroid of the tidal polygon <br/>LATITUDE is the latitude of the centroid of the tidal polygon <br/>START DATE is the beginning of the date range covered by the file <br/>END DATE is the end of the date range covered by the file <br/>PERCENTILE TIDE RANGE indicates the percentile value used when calculating the composites <p/> The index of downloadable GeoTIFFs can be found here: <p/> http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/catalog.xml"
+                        },
+                        {
+                           "name": "References",
+                           "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmospheric Ocean. Technol. 19, 183-204. doi:10.1175/1520-0426(2002)019<0183:EIMOBO>2.0.CO;2 <p/> Egbert, G.D., Erofeeva, S.Y., 2010. The OSU TOPEX/Poseiden Global Inverse Solution TPXO [WWW Document]. TPXO8-Atlas Version 10. URL http://volkov.oce.orst.edu/tides/global.html (accessed 2.15.16). <p/> Geoscience Australia, 2016. Intertidal Extents Model (25m) v 1.0 Product Description. doi:10.4225/25/575F683E2A3AF <p/> Li, F., Jupp, D.L.B., Thankappan, M., Lymburner, L., Mueller, N., Lewis, A., Held, A., 2012. A physics-based atmospheric and BRDF correction for Landsat data over mountainous terrain. Remote Sens. Environ. 124, 756-770. doi:10.1016/j.rse.2012.06.018 <p/> Roberts, D., Mueller, N., McIntyre, A., 2017. High-dimensional pixel composites from Earth observation time series. IEEE Trans. Geosci. Remote Sens. In Press. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sens. Environ. 195, 153-169. doi:10.1016/j.rse.2017.04.009 <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
+                        }
+                     ]
+                  }
+               ]
+            },
+            {
+               "name": "High tide satelitte images",
+               "type": "group",
+               "preserveOrder": true,
+               "items": [
+                  {
+                     "name": "High tide Landsat satellite images",
+                     "type": "wms",
+                     "layers": "high_tide_composite",
+                     "url": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                     "linkedWcsCoverage": "high_tide_composite",
+                     "ignoreUnknownTileErrors": true,
+                     "opacity": 1
+                  },
+                  {
+                     "name": "High Tide Polygons for data access",
+                     "type": "geojson",
+                     "url": "https://data.dea.ga.gov.au/LHTC_Tides/high_composite_20.geojson",
+                     "featureInfoTemplate": {
+                        "template": "The tidal range at this location is {{modelLow}} to {{modelHigh}} meters relative to mean sea level (MSL). <p/> The high tide composite at this location was generated from imagery acquired in the top 20% of the observed tidal range which is between {{LIT}} and {{HIT}} meters relative to MSL, during the period of time of {{date_range}}. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/LHTC_Tides/COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.jpg'/> <figcaption>Observations used to generate the composite (black dots), in relation to the full modelled tidal range (blue) and complete archive (white dots) at this location</figcaption> </figure> <p/> Download the GeoTIFF for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif'>COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif</a>"
+                     },
+                     "info": [
+                        {
+                           "name": "Abstract",
+                           "content": "High Tide and Low Tide Composites 2.0.0 <p/> The High and Low Tide Composites product is composed of two surface reflectance composite mosaics of Landsat TM and ETM+ (Landsat 5 and Landsat 7 respectively) and OLI (Landsat 8) surface reflectance data (Li et al., 2012). These products have been produced using Digital Earth Australia (DEA). The two mosaics allow cloud free and noise reduced visualisation of the shallow water and inter-tidal coastal regions of Australia, as observed at high and low tide respectively (Sagar et al. 2018). <p/> The composites are generated utilising the geomedian approach of Roberts et al (2017) to ensure a valid surface reflectance spectra suitable for uses such as habitat mapping. The time range used for composite generation in each polygon of the mosaic is tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The concepts of the Observed Tidal Range (OTR), and Highest and Lowest Observed Tide (HOT, LOT) are discussed and described fully in Sagar et al. (2017) and the product description for the ITEM v 1.0 product (Geoscience Australia, 2016)."
+                        },
+                        {
+                           "name": "Overview",
+                           "content": "Inter-tidal zones are difficult regions to characterise due to the dynamic nature of the tide. They are highly changeable environments, subject to forcings from the land, sea and atmosphere and yet they form critical habitats for a wide range of organisms from birds to fish and sea grass. By harnessing the long archive of satellite imagery over Australia's coastal zones in the DEA and pairing the images with regional tidal modelling, the archive can be sorted by tide height rather than date, enabling the inter-tidal zone to be viewed at any stage of the tide regime. <p/> The High Low Tide Composites (HLTC_25) product is composed of two mosaics, distinguished by tide height, representing a composite image of the synthetic geomedian surface reflectance from Landsats 5 TM, Landsat 7 ETM+ and Landsat 8 OLI NBAR data (Li et al., 2012; Roberts et al., 2017). Oregon State Tidal Prediction (OTPS) software (Egbert and Erofeeva, 2002, 2010) was used to generate tide heights, relative to mean sea level, for the Australian continental coastline, split into 306 distinct tidal regions. These time and date stamped tidal values were then attributed to all coastal tile observations for their time of acquisition, creating a range of observed tide heights for the Australian coastline. The two mosaics in HLTC_25 are composited from the highest and lowest 20 % of observed tide in the ensemble and are termed HOT and LOT respectively. A geomedian composite for each Landsat band is calculated from the tiles in each ensemble subset to produce the respective HOT and LOT composites. Note that Landsat 7 ETM+ observations are excluded after May 2003 due to a large number of data artefacts. <p/> The time range used for composite generation in each of the 306 polygons of the mosaics are tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The maximum epoch for which the products are calculated is between 1995-2017, although this varies due to data resolution and observation quality. The product also includes a count of clear observations per pixel for both mosaics and attribute summaries per polygon that include the date range, the highest and lowest modeled astronomical tide as well as the highest and lowest observed tide for that time range, the total observation count and the maximum count of observations for any one pixel in the polygon, the polygon ID number (from 1 to 306), the polygon centroid in longitude and latitude and the count of tide stages attributed to every observation used in that polygon of the mosaic. For the count of tidal stage observations, e = ebbing tide, f = flowing tide, ph = peak high tide and pl = peak low tide. The tide stages were calculated by comparison to the modeled tide data for 15 minutes either side of the observation to determine the ebb, flow or peak movement of the tide. <p/> Observations are filtered to remove poor quality observations including cloud, cloud shadow and band saturation (of any band)."
+                        },
+                        {
+                           "name": "Accuracy and limitations",
+                           "content": "The accuracy of the tide height data is limited by the accuracy of the OTPS model. Tidal modelling on self-similar coastal polygons was performed to minimise regional uncertainty. <p/> Accuracies and limitations related to geomedian compositing of observations are discussed in Roberts et al (2017). <p/> Users should beware of seasonal and diurnal effects in the imagery, especially in the north east of Australia where the footprint of the highest and lowest astronomical tides are large. Consequently, where image acquisition misses the highest astronomical tide, for example, pooling effects of water are still visible in the landscape in lowest observed tidal composite imagery. <p/> This product has been rendered in both true colour and false colour. Validation and interpretation of surface features has not been attempted here. Interpretation of surface features is at the users own discretion."
+                        },
+                        {
+                           "name": "File naming",
+                           "content": "`<COUNT OR COMPOSITE>_<HIGH OR LOW>_<TIDAL POLYGON NUMBER>_<LONGITUDE>_<LATITUDE>_<START DATE>_<END DATE>_<PERCENTILE TIDE RANGE>` <p/> COUNT OR COMPOSITE refers to whether pixels contain composite observation values or the count of observations at that pixel location <br/>HIGH OR LOW refers to whether the content relates to High Tide values or Low Tide values <br/>TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <br/>LONGITUDE is the longitude of the centroid of the tidal polygon <br/>LATITUDE is the latitude of the centroid of the tidal polygon <br/>START DATE is the beginning of the date range covered by the file <br/>END DATE is the end of the date range covered by the file <br/>PERCENTILE TIDE RANGE indicates the percentile value used when calculating the composites <p/> The index of downloadable GeoTIFFs can be found here: <p/> http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/catalog.xml"
+                        },
+                        {
+                           "name": "References",
+                           "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmospheric Ocean. Technol. 19, 183-204. doi:10.1175/1520-0426(2002)019<0183:EIMOBO>2.0.CO;2 <p/> Egbert, G.D., Erofeeva, S.Y., 2010. The OSU TOPEX/Poseiden Global Inverse Solution TPXO [WWW Document]. TPXO8-Atlas Version 10. URL http://volkov.oce.orst.edu/tides/global.html (accessed 2.15.16). <p/> Geoscience Australia, 2016. Intertidal Extents Model (25m) v 1.0 Product Description. doi:10.4225/25/575F683E2A3AF <p/> Li, F., Jupp, D.L.B., Thankappan, M., Lymburner, L., Mueller, N., Lewis, A., Held, A., 2012. A physics-based atmospheric and BRDF correction for Landsat data over mountainous terrain. Remote Sens. Environ. 124, 756-770. doi:10.1016/j.rse.2012.06.018 <p/> Roberts, D., Mueller, N., McIntyre, A., 2017. High-dimensional pixel composites from Earth observation time series. IEEE Trans. Geosci. Remote Sens. In Press. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sens. Environ. 195, 153-169. doi:10.1016/j.rse.2017.04.009 <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
+                        }
+                     ]
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}


### PR DESCRIPTION
This catalog is intended for maps.dea.ga.gov.au - it should only include DEA products from GSKY and our production stack. The order is intended to encourage easier traversal of our services, however some decisions are bound to be controversial so this should expect to change a bit as we receive feedback.