### PR TITLE
Add Collection 3 beta layer

### DIFF
--- a/dev/terria/dea.json
+++ b/dev/terria/dea.json
@@ -16,8 +16,54 @@
    "catalog": [
       {
          "name": "GSKY DEA Collection 3 Beta",
-         "type": "wms-getCapabilities",
-         "url": "http://gsky.nci.org.au/ows/beta-dea"
+	 "type": "group",
+         "preserveOrder": true,
+         "items": [
+            {
+               "name": "Multi-sensor (Landsat and Sentinel 2) surface reflectance (Beta)",
+               "type": "wms",
+               "url": "http://gsky.nci.org.au/ows/beta-dea",
+               "layers": "blend_sentinel2_landsat_nbart_daily",
+               "ignoreUnknownTileErrors": true,
+               "chartType": "momentPoints",
+               "chartColor": "white",
+               "opacity": 1,
+               "featureTimesProperty": "data_available_for_dates"
+            },
+	    {
+               "name": "Landsat 8 Daily",
+               "type": "wms",
+               "url": "http://gsky.nci.org.au/ows/beta-dea",
+               "layers": "landsat8_nbart_daily",
+               "ignoreUnknownTileErrors": true,
+               "chartType": "momentPoints",
+               "chartColor": "white",
+               "opacity": 1,
+               "featureTimesProperty": "data_available_for_dates"
+            },
+	    {
+               "name": "Landsat 7 Daily",
+               "type": "wms",
+               "url": "http://gsky.nci.org.au/ows/beta-dea",
+               "layers": "landsat7_nbart_daily",
+               "ignoreUnknownTileErrors": true,
+               "chartType": "momentPoints",
+               "chartColor": "white",
+               "opacity": 1,
+               "featureTimesProperty": "data_available_for_dates"
+            },
+	    {
+               "name": "Landsat 5 Daily",
+               "type": "wms",
+               "url": "http://gsky.nci.org.au/ows/beta-dea",
+               "layers": "landsat5_nbart_daily",
+               "ignoreUnknownTileErrors": true,
+               "chartType": "momentPoints",
+               "chartColor": "white",
+               "opacity": 1,
+               "featureTimesProperty": "data_available_for_dates"
+            }
+         ]
       },
       {
          "name": "GSKY Blended Service",
@@ -28,18 +74,7 @@
                "name": "Multi-sensor (Landsat and Sentinel 2) surface reflectance true colour (Beta)",
                "type": "wms",
                "url": "https://gsky.nci.org.au/ows/dea",
-               "layers": "blend_sentinel2_landsat_nbart_daily_true_colour",
-               "ignoreUnknownTileErrors": true,
-               "chartType": "momentPoints",
-               "chartColor": "white",
-               "opacity": 1,
-               "featureTimesProperty": "data_available_for_dates"
-            },
-            {
-               "name": "Multi-sensor (Landsat and Sentinel 2) surface reflectance false colour (Beta)",
-               "type": "wms",
-               "url": "https://gsky.nci.org.au/ows/dea",
-               "layers": "blend_sentinel2_landsat_nbart_daily_false_colour",
+               "layers": "blend_sentinel2_landsat_nbart_daily",
                "ignoreUnknownTileErrors": true,
                "chartType": "momentPoints",
                "chartColor": "white",

--- a/dev/terria/dea.json
+++ b/dev/terria/dea.json
@@ -15,22 +15,9 @@
    },
    "catalog": [
       {
-         "name": "GSKY DEA Functional Testing",
-         "type": "group",
-         "preserveOrder": true,
-         "items": [
-            {
-               "name": "Blended service",
-               "type": "wms",
-               "url": "http://130.56.242.6/ows/fusion",
-               "layers": "blended",
-               "ignoreUnknownTileErrors": true,
-               "chartType": "momentPoints",
-               "chartColor": "white",
-               "opacity": 1,
-               "featureTimesProperty": "data_available_for_dates"
-            }
-         ]
+         "name": "GSKY DEA Collection 3 Beta",
+         "type": "wms-getCapabilities",
+         "url": "http://gsky.nci.org.au/ows/beta-dea"
       },
       {
          "name": "GSKY Blended Service",


### PR DESCRIPTION
NCI have released a new endpoint, replacing our Landsat collection 2 with Landsat collection 3. One point of improvement is that the "valid data polygon" should be more accurate, so data available for dates should work better.
