### PR TITLE
Make sentinel 2 definitive pull ranges from the database instead of caching it

### DIFF
--- a/dev/services/wms/ows/ows_cfg.py
+++ b/dev/services/wms/ows/ows_cfg.py
@@ -6092,6 +6092,7 @@ For service status information, see https://status.dea.ga.gov.au
                     "product_names": [ "s2a_ard_granule", "s2b_ard_granule" ],
                     "bands": bands_sentinel2,
                     "resource_limits": reslim_s2_ard,
+                    "dynamic": True,
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],
@@ -6125,6 +6126,7 @@ This is a definitive archive of daily Sentinel-2 data. This is processed using c
                     "product_name": "s2b_ard_granule",
                     "bands": bands_sentinel2,
                     "resource_limits": reslim_s2_ard,
+                    "dynamic": True,
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],
@@ -6158,6 +6160,7 @@ This is a definitive archive of daily Sentinel-2 data. This is processed using c
                     "product_name": "s2a_ard_granule",
                     "bands": bands_sentinel2,
                     "resource_limits": reslim_s2_ard,
+                    "dynamic": True,
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],


### PR DESCRIPTION
Make sentinel 2 definitive pull ranges from the database instead of caching it.

- Combined s2a / s2b
- s2a
- s2b

We're regularly indexing datasets from thredds, which means the temporal ranges are changing each day. If a layer isn't marked as dynamic it will only update the temporal ranges when pods are restarted. This can cause some issues when we scale up as newer servers will report updated ranges, and older servers won't know how to honour them. The fix is to pull ranges from the database for these products that change often.

This change will affect dev, if successful we can roll a similar change to production.