### PR TITLE
configure fc and wofs daily products to be dynamic

### DIFF
--- a/dev/services/wms/ows/ows_cfg.py
+++ b/dev/services/wms/ows/ows_cfg.py
@@ -5943,6 +5943,7 @@ For service status information, see https://status.dea.ga.gov.au
                     "product_name": "wofs_albers",
                     "bands": bands_wofs_obs,
                     "resource_limits": reslim_wofs_obs,
+                    "dynamic": True,
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_bitflag",
                         "always_fetch_bands": [ ],
@@ -8200,6 +8201,7 @@ For service status information, see https://status.dea.ga.gov.au
                     "product_name": "ls7_fc_albers",
                     "bands": bands_fc,
                     "resource_limits": reslim_aster,
+                    "dynamic": True,
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],
@@ -8240,6 +8242,7 @@ For service status information, see https://status.dea.ga.gov.au
                     "product_name": "ls8_fc_albers",
                     "bands": bands_fc,
                     "resource_limits": reslim_aster,
+                    "dynamic": True,
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],
@@ -8274,6 +8277,7 @@ Fractional Cover version 2.2.1, 25 metre, 100km tile, Australian Albers Equal Ar
                     "product_names": [ "ls5_fc_albers", "ls7_fc_albers", "ls8_fc_albers" ],
                     "bands": bands_fc,
                     "resource_limits": reslim_aster,
+                    "dynamic": True,
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],


### PR DESCRIPTION
As ows will cache temporal extents on startup, things that are updated daily should be configured to be dynamic (pull temporal extents from database) - otherwise we get into an awkward state when newer ows pods have different extents to the older ones, especially a problem when we have autoscaled. 

This change ensures that all products that are updated daily are set to dynamic

- S2 Definitive a, b, a+b (already set)
- S2 NRT a, b, a+b (already set)
- FC L7, L8 5+7+8 
- WOFL 

N.B. I intentionally didn't set dynamic on FC L5 as it is not being produced daily. Enabling dynamic increases load on the DB and performance of getCaps so we should use it sparingly. 