### PR TITLE
Configure fc 7,8,combined and wofs_albers to be dynamic

### DIFF
--- a/prod/services/wms/ows/ows_cfg.py
+++ b/prod/services/wms/ows/ows_cfg.py
@@ -5557,6 +5557,7 @@ For service status information, see https://status.dea.ga.gov.au
                     "product_name": "wofs_albers",
                     "bands": bands_wofs_obs,
                     "resource_limits": reslim_wofs_obs,
+                    "dynamic": True,
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_bitflag",
                         "always_fetch_bands": [ ],
@@ -7814,6 +7815,7 @@ For service status information, see https://status.dea.ga.gov.au
                     "product_name": "ls7_fc_albers",
                     "bands": bands_fc,
                     "resource_limits": reslim_aster,
+                    "dynamic": True,
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],
@@ -7854,6 +7856,7 @@ For service status information, see https://status.dea.ga.gov.au
                     "product_name": "ls8_fc_albers",
                     "bands": bands_fc,
                     "resource_limits": reslim_aster,
+                    "dynamic": True,
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],
@@ -7888,6 +7891,7 @@ Fractional Cover version 2.2.1, 25 metre, 100km tile, Australian Albers Equal Ar
                     "product_names": [ "ls5_fc_albers", "ls7_fc_albers", "ls8_fc_albers" ],
                     "bands": bands_fc,
                     "resource_limits": reslim_aster,
+                    "dynamic": True,
                     "image_processing": {
                         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
                         "always_fetch_bands": [ ],


### PR DESCRIPTION
Testing for change #538 was successful, this change is to roll those changes out to the production environment. 

I did uncover some separate bugs unrelated to this change, that will be solved in future work
- missing .tif files in ls7 fractional cover
- fc multiproduct isn't being frequently updated 
