### PR TITLE
rename s2 nrt products

### DIFF
--- a/products/nrt/sentinel/s2_nrt.products.yaml
+++ b/products/nrt/sentinel/s2_nrt.products.yaml
@@ -3,7 +3,7 @@
 # New product def for NRT S2MSIARD
 ---
 
-name: s2a_msiard_nrt_granule
+name: s2a_nrt_granule
 description: Sentinel-2A MSI ARD NRT - NBAR NBART and Pixel Quality
 metadata_type: eo_s2_nrt
 
@@ -795,7 +795,7 @@ measurements:
 
 ---
 
-name: s2b_msiard_nrt_granule
+name: s2b_nrt_granule
 description: Sentinel-2B MSI ARD NRT - NBAR NBART and Pixel Quality
 metadata_type: eo_s2_nrt
 


### PR DESCRIPTION
following the discussion from sprint planning, s2 nrt products will continue to use its current name.