### PR TITLE
add general issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/general-issue-template.md
@@ -1,0 +1,10 @@
+---
+name: general issue template
+about: any issues
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
by adding an issue template, the default gets overwritten, add it back. 

issue templates are in this folder, https://github.com/GeoscienceAustralia/dea-config/tree/master/.github/ISSUE_TEMPLATE

under different file names/