### PR TITLE
Update s2_nrt_wo.alchemist.yaml with naming conventions

### DIFF
--- a/dev/services/alchemist/s2_nrt_wo/s2_nrt_wo.alchemist.yaml
+++ b/dev/services/alchemist/s2_nrt_wo/s2_nrt_wo.alchemist.yaml
@@ -42,6 +42,7 @@ output:
     producer: ga.gov.au
     dataset_version: 0.0.1
     collection_number: 3
+    naming_conventions: dea_s2_derivative
 
   properties:
     dea:dataset_maturity: nrt


### PR DESCRIPTION
Adds `dea_s2_derivative` naming conventions to S2 NRT WO which should merge s2a and s2b,