### PR TITLE
Differentiate Landsat 7 Pan band from Landsat 8

### DIFF
--- a/dev/services/wms/ows_refactored/c3/ows_c3_cfg.py
+++ b/dev/services/wms/ows_refactored/c3/ows_c3_cfg.py
@@ -41,10 +41,22 @@ style_c3_pure_aerosol = {
     "scale_range": [0.0, 3000.0],
 }
 
-style_c3_pure_panchromatic = {
+style_c3_ls7_pure_panchromatic = {
     "name": "panchromatic",
-    "title": "Pure Panchromatic",
-    "abstract": "panchromatic",
+    "title": "Panchromatic - 710",
+    "abstract": "Panchromatic, centered on 710nm",
+    "components": {
+        "red": {"nbart_panchromatic": 1.0},
+        "green": {"nbart_panchromatic": 1.0},
+        "blue": {"nbart_panchromatic": 1.0},
+    },
+    "scale_range": [0.0, 3000.0],
+}
+
+style_c3_ls8_pure_panchromatic = {
+    "name": "panchromatic",
+    "title": "Panchromatic - 590",
+    "abstract": "Panchromatic, centered on 590nm",
     "components": {
         "red": {"nbart_panchromatic": 1.0},
         "green": {"nbart_panchromatic": 1.0},
@@ -262,9 +274,10 @@ styles_c3_ls_common = [
 
 
 styles_c3_ls_7 = styles_c3_ls_common.copy()
-styles_c3_ls_7.append(style_c3_pure_panchromatic)
+styles_c3_ls_7.append(style_c3_ls7_pure_panchromatic)
 
-styles_c3_ls_8 = styles_c3_ls_7.copy()
+styles_c3_ls_8 = styles_c3_ls_common.copy()
+styles_c3_ls_8.append(style_c3_ls8_pure_panchromatic)
 styles_c3_ls_8.append(style_c3_pure_aerosol)
 
 


### PR DESCRIPTION
Landsat 7 and Landsat 8 both have Pancromatic (Pan) bands, but they are very different,
Landsat 7 spans green, red and nir bands while Landsat 8 spans blue, green and red. Just updating their style (presentation title/name) to reflect that