### PR TITLE
Mask sea from C3 LS ndvi and nbr styles with geodata.

### DIFF
--- a/dev/services/wms/ows_refactored/c3/ows_c3_cfg.py
+++ b/dev/services/wms/ows_refactored/c3/ows_c3_cfg.py
@@ -75,6 +75,12 @@ The resolution is a 30 m grid based on the USGS Landsat Collection 1 archive."""
                     "ignore_time": False,
                     "ignore_info_flags": [],
                 },
+                {
+                    "band": "land",
+                    "product": "geodata_coast_100k",
+                    "ignore_time": True,
+                    "ignore_info_flags": []
+                },
             ],
             "wcs": {
                 "native_crs": "EPSG:3577",
@@ -110,6 +116,12 @@ For service status information, see https://status.dea.ga.gov.au""",
                     "product": "ga_ls7e_ard_3",
                     "ignore_time": False,
                     "ignore_info_flags": [],
+                },
+                {
+                    "band": "land",
+                    "product": "geodata_coast_100k",
+                    "ignore_time": True,
+                    "ignore_info_flags": []
                 },
             ],
             "wcs": {
@@ -149,6 +161,12 @@ For service status information, see https://status.dea.ga.gov.au""",
                     "product": "ga_ls5t_ard_3",
                     "ignore_time": False,
                     "ignore_info_flags": [],
+                },
+                {
+                    "band": "land",
+                    "product": "geodata_coast_100k",
+                    "ignore_time": True,
+                    "ignore_info_flags": []
                 },
             ],
             "wcs": {
@@ -193,6 +211,16 @@ For service status information, see https://status.dea.ga.gov.au""",
                     ],
                     "ignore_time": False,
                     "ignore_info_flags": [],
+                },
+                {
+                    "band": "land",
+                    "products": [
+                        "geodata_coast_100k",
+                        "geodata_coast_100k",
+                        "geodata_coast_100k",
+                    ],
+                    "ignore_time": True,
+                    "ignore_info_flags": []
                 },
             ],
             "wcs": {

--- a/dev/services/wms/ows_refactored/c3/style_c3_cfg.py
+++ b/dev/services/wms/ows_refactored/c3/style_c3_cfg.py
@@ -115,6 +115,11 @@ style_c3_ndvi = {
             "enum": 3,
             "invert": True,
         },
+        {
+            "band": "land",
+            "invert": True,
+            "enum": 1,
+        },
     ],
     "legend": legend_idx_0_1_5ticks,
 }
@@ -350,6 +355,11 @@ style_c3_nbr = {
             "enum": 3,
             "invert": True,
         },
+        {
+            "band": "land",
+            "invert": True,
+            "enum": 1,
+        },
     ],
     "legend": {
         "show_legend": True,
@@ -410,6 +420,11 @@ style_c3_nbr = {
                     "band": "oa_fmask",
                     "enum": 3,
                     "invert": True,
+                },
+                {
+                    "band": "land",
+                    "invert": True,
+                    "enum": 1,
                 },
             ],
             "legend": {


### PR DESCRIPTION
Apply geodata sea-masking to C3 Landsat NDVI and NBR styles, as discussed in this morning's C3 meeting.