### PR TITLE
Add updated DEA Coastlines config as backup option for release

### DIFF
--- a/dev/terria/dea-maps.json
+++ b/dev/terria/dea-maps.json
@@ -1013,61 +1013,60 @@
          "preserveOrder": true,
          "items": [
             {
-               "name": "Digital Earth Australia Coastlines",
-               "type": "group",
-               "preserveOrder": true,
-               "items": [
-                  {
-                     "type": "wms",
-                     "name": "Digital Earth Australia Coastlines (beta)",
-                     "id": "dea_coastlines",
-                     "url": "https://geoserver.dea.ga.gov.au/geoserver/wms",
-                     "opacity": "1.0",
-                     "layers": "dea:DEACoastLines",
-                     "shortReport": "<i>Zoom in to view detailed rates of coastal change and individual annual coastlines<\/i>",
-                     "legendUrl": "https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_legend 1.png",
-                     "zoomOnEnable": true,
-                     "chartDisclaimer": "The graph below shows the distance (in metres) from each 1988-2018 coastline relative to the 2019 baseline. Negative distances below indicate coastlines that were located inland of the 2019 coastline, while positive values indicate coastlines located towards the ocean.",
-                     "featureInfoTemplate": {
-                        "template": "<div style='width:480px'>{{#n}}<h3 style='font-weight:normal'>Digital Earth Australia Coastlines<\/h3>Zoom in until labelled points appear and click on any point to view a <b>time series chart of how an area of coastline has changed over time<\/b> (press 'Expand' on the pop-up for more detail):<\/br><\/br><img src='https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_DEAMaps_1.gif' alt='Clicking on points'><\/br><\/br>Zoom in further to view individual annual coastlines:<\/br><\/br><img src='https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_DEAMaps_2.gif' alt='Zooming to coastlines'>{{/n}}{{#sce}}<h2 style='font-weight:normal'>This coastline has <b>{{#retreat}}retreated{{/retreat}}{{#growth}}grown{{/growth}}<\/b> by<\/br> <b>{{#terria.formatNumber}}{maximumFractionDigits:1}{{rate_time}}{{/terria.formatNumber}} metres (±{{#terria.formatNumber}}{maximumFractionDigits:1}{{conf_time}}{{/terria.formatNumber}}) per year<\/b><\/br>on average since <b>1988<\/b><\/h2>The coastline at this location was <b>most seaward in {{max_year}}<\/b>, and <b>most landward in {{min_year}}<\/b>{{#outl_time}} (excluding outlier years; see below){{/outl_time}}. Since 1988, the coastline has moved over a total distance of approximately <b>{{#terria.formatNumber}}{maximumFractionDigits:0}{{sce}}{{/terria.formatNumber}} metres.<\/b><\/br><\/br><chart title='DEA Coastlines ({{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.latitude}}{{/terria.formatNumber}}, {{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.longitude}}{{/terria.formatNumber}})' y-column='Distance (metres) relative to 2019 coastline' x-column='Year' column-units='{{terria.timeSeries.units}}' preview-x-label='Year'>Year,Distance (metres) relative to 2019 coastline\n1988,{{dist_1988}}\n1989,{{dist_1989}}\n1990,{{dist_1990}}\n1991,{{dist_1991}}\n1992,{{dist_1992}}\n1993,{{dist_1993}}\n1994,{{dist_1994}}\n1995,{{dist_1995}}\n1996,{{dist_1996}}\n1997,{{dist_1997}}\n1998,{{dist_1998}}\n1999,{{dist_1999}}\n2000,{{dist_2000}}\n2001,{{dist_2001}}\n2002,{{dist_2002}}\n2003,{{dist_2003}}\n2004,{{dist_2004}}\n2005,{{dist_2005}}\n2006,{{dist_2006}}\n2007,{{dist_2007}}\n2008,{{dist_2008}}\n2009,{{dist_2009}}\n2010,{{dist_2010}}\n2011,{{dist_2011}}\n2012,{{dist_2012}}\n2013,{{dist_2013}}\n2014,{{dist_2014}}\n2015,{{dist_2015}}\n2016,{{dist_2016}}\n2017,{{dist_2017}}\n2018,{{dist_2018}}\n2019,{{dist_2019}}<\/chart>{{#outl_time}}The following years were identified as potential outliers, and should be interpreted with caution:<\/br><\/br><b>{{outl_time}}<\/b>{{/outl_time}}{{/sce}}{{#year}}<h2 style='font-weight:normal'>{{year}} annual coastline<\/h2><h3 style='font-weight:normal'>Certainty: {{certainty}}<\/h3>Annual coastlines represent the typical (i.e. median) position of the shoreline at approximately mean sea level (~0 m AHD) across the entire year period.<\/br><\/br>{{/year}}<\/div>"
-                     }
-                  },
-                  {
-                     "name": "Supplementary layers",
-                     "type": "group",
-                     "preserveOrder": true,
-                     "items": [
-                        {
-                           "type": "wms",
-                           "name": "Annual coastlines",
-                           "id": "dea_coastlines_annual",
-                           "url": "https://geoserver.dea.ga.gov.au/geoserver/wms",
-                           "opacity": "1.0",
-                           "layers": "dea:AnnualCoastlines",
-                           "shortReport": "<i>Zoom in to view individual annual coastlines from 1988 to the present<\/i>",
-                           "legendUrl": "https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_legend 1.png",
-                           "featureInfoTemplate": {
-                              "template": "<div style='width:480px'><h2 style='font-weight:normal'>{{year}} annual coastline<\/h2><h3 style='font-weight:normal'>Certainty: {{certainty}}<\/h3>Annual coastlines represent the typical (i.e. median) position of the shoreline at approximately mean sea level (~0 m AHD) across the entire year period.<\/br><\/br><\/div>"
-                           }
-                        },
-                        {
-                           "type": "wms",
-                           "name": "Rates of change statistics",
-                           "id": "dea_coastlines_statistics",
-                           "url": "https://geoserver.dea.ga.gov.au/geoserver/wms",
-                           "opacity": "1.0",
-                           "layers": "dea:RateOfChangeStatistics",
-                           "shortReport": "<i>Zoom in to view detailed rates of coastal change along the Australian coastline<\/i>",
-                           "legendUrl": "https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_legend 1.png",
-                           "chartDisclaimer": "The graph below shows the distance (in metres) from each 1988-2018 coastline relative to the 2019 baseline. Negative distances below indicate coastlines that were located inland of the 2019 coastline, while positive values indicate coastlines located towards the ocean.",
-                           "featureInfoTemplate": {
-                              "template": "<div style='width:480px'><h2 style='font-weight:normal'>This coastline has <b>{{#retreat}}retreated{{/retreat}}{{#growth}}grown{{/growth}}<\/b> by<\/br> <b>{{#terria.formatNumber}}{maximumFractionDigits:1}{{rate_time}}{{/terria.formatNumber}} metres (±{{#terria.formatNumber}}{maximumFractionDigits:1}{{conf_time}}{{/terria.formatNumber}}) per year<\/b><\/br>on average since <b>1988<\/b><\/h2>The coastline at this location was <b>most seaward in {{max_year}}<\/b>, and <b>most landward in {{min_year}}<\/b>{{#outl_time}} (excluding outlier years; see below){{/outl_time}}. Since 1988, the coastline has moved over a total distance of approximately <b>{{#terria.formatNumber}}{maximumFractionDigits:0}{{sce}}{{/terria.formatNumber}} metres.<\/b><\/br><\/br><chart title='DEA Coastlines ({{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.latitude}}{{/terria.formatNumber}}, {{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.longitude}}{{/terria.formatNumber}})' y-column='Distance (metres) relative to 2019 coastline' x-column='Year' column-units='{{terria.timeSeries.units}}' preview-x-label='Year'>Year,Distance (metres) relative to 2019 coastline\n1988,{{dist_1988}}\n1989,{{dist_1989}}\n1990,{{dist_1990}}\n1991,{{dist_1991}}\n1992,{{dist_1992}}\n1993,{{dist_1993}}\n1994,{{dist_1994}}\n1995,{{dist_1995}}\n1996,{{dist_1996}}\n1997,{{dist_1997}}\n1998,{{dist_1998}}\n1999,{{dist_1999}}\n2000,{{dist_2000}}\n2001,{{dist_2001}}\n2002,{{dist_2002}}\n2003,{{dist_2003}}\n2004,{{dist_2004}}\n2005,{{dist_2005}}\n2006,{{dist_2006}}\n2007,{{dist_2007}}\n2008,{{dist_2008}}\n2009,{{dist_2009}}\n2010,{{dist_2010}}\n2011,{{dist_2011}}\n2012,{{dist_2012}}\n2013,{{dist_2013}}\n2014,{{dist_2014}}\n2015,{{dist_2015}}\n2016,{{dist_2016}}\n2017,{{dist_2017}}\n2018,{{dist_2018}}\n2019,{{dist_2019}}<\/chart>{{#outl_time}}The following years were identified as potential outliers, and should be interpreted with caution:<\/br><\/br><b>{{outl_time}}<\/b>{{/outl_time}}<\/div>"
-                           }
-                        }
-                     ]
-                  }
-               ]
-            },
+			   "name":"Digital Earth Australia Coastlines",
+			   "type":"group",
+			   "preserveOrder":true,
+			   "items":[
+				  {
+					 "type":"wms",
+					 "name":"Digital Earth Australia Coastlines",
+					 "id": "dea_coastlines2",
+					 "url":"https://geoserver.dea.ga.gov.au/geoserver/wms",
+					 "opacity":"1.0",
+					 "layers":"dea:DEACoastLines",
+					 "shortReport":"<i>Zoom in to view detailed rates of coastal change and individual annual coastlines</i></br></br><small>For more information and to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description</a></small>",
+					 "legendUrl":"https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_legend 1.png",
+					 "chartDisclaimer":"The graph below shows the distance (in metres) from each 1988-2018 coastline to the 2019 coastline. Positive distances indicate that a coastline was located towards the ocean from the 2019 coastline; coastlines with negative distances were located further inland.",
+					 "featureInfoTemplate":{
+						"template": "<div style='width:480px'>{{#n}}<h3 style='font-weight:normal'>Digital Earth Australia Coastlines</h3>Zoom in until labelled points appear and click on any point to view a <b>time series chart of how the local coastline has changed over time</b> (press 'Expand' on the pop-up for more detail):</br></br><img src='https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_DEAMaps_1.gif' alt='Clicking on points'></br></br>Zoom in further to view individual annual coastlines:</br></br><img src='https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_DEAMaps_2.gif' alt='Zooming to coastlines'><i></br></br>For more information or to download DEA Coastlines data, view the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description.</a></i></br></br>{{/n}}{{#sce}}<h2 style='font-weight:normal'>This coastline has <b>{{#retreat}}retreated &darr;{{/retreat}}{{#growth}}grown &uarr;{{/growth}}</b> by</br> <b>{{#terria.formatNumber}}{maximumFractionDigits:1}{{rate_time}}{{/terria.formatNumber}} metres (±{{#terria.formatNumber}}{maximumFractionDigits:1}{{conf_time}}{{/terria.formatNumber}}) per year</b></br>on average since <b>1988</b></h2>The coastline at this location was <b>most seaward in {{max_year}}</b>, and <b>most landward in {{min_year}}</b>{{#outl_time}} (excluding outlier years; see below){{/outl_time}}. Since 1988, the coastline has moved over a total distance of approximately <b>{{#terria.formatNumber}}{maximumFractionDigits:0}{{sce}}{{/terria.formatNumber}} metres.</b></br></br><chart title='DEA Coastlines ({{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.latitude}}{{/terria.formatNumber}}, {{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.longitude}}{{/terria.formatNumber}})' y-column='Distance (metres) relative to 2019 coastline' x-column='Year' column-units='{{terria.timeSeries.units}}' preview-x-label='Year'>Year,Distance (metres) relative to 2019 coastline\n1988,{{dist_1988}}\n1989,{{dist_1989}}\n1990,{{dist_1990}}\n1991,{{dist_1991}}\n1992,{{dist_1992}}\n1993,{{dist_1993}}\n1994,{{dist_1994}}\n1995,{{dist_1995}}\n1996,{{dist_1996}}\n1997,{{dist_1997}}\n1998,{{dist_1998}}\n1999,{{dist_1999}}\n2000,{{dist_2000}}\n2001,{{dist_2001}}\n2002,{{dist_2002}}\n2003,{{dist_2003}}\n2004,{{dist_2004}}\n2005,{{dist_2005}}\n2006,{{dist_2006}}\n2007,{{dist_2007}}\n2008,{{dist_2008}}\n2009,{{dist_2009}}\n2010,{{dist_2010}}\n2011,{{dist_2011}}\n2012,{{dist_2012}}\n2013,{{dist_2013}}\n2014,{{dist_2014}}\n2015,{{dist_2015}}\n2016,{{dist_2016}}\n2017,{{dist_2017}}\n2018,{{dist_2018}}\n2019,{{dist_2019}}</chart>{{#outl_time}}The following years were identified as potential outliers, and should be interpreted with caution:</br></br><b>{{outl_time}}</b></br>{{/outl_time}}<i></br>For more information about the DEA Coastlines coastal change statistics or to download data, view the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description.</a></i></br></br>{{/sce}}{{#year}}<h2 style='font-weight:normal'>{{year}} annual coastline</h2>This line represents the approximate <b>median</b> (i.e. 'typical') position of the coastline at <b>0 m Above Mean Sea Level</b> across the entire of {{year}}.</br></br><h3 style='font-weight:normal'>{{#wms_aero}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>aerosol issues</b> caused by the 1991 eruption of Mount Pinatubo.</blockquote>{{/wms_aero}}{{#wms_tidal}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>tidal modelling issues</b>, potentially caused by errors in the tidal model used to constrain coastlines to mean sea level, or the influence of shallow intertidal topography that can lead to inaccurate coastline mapping.</blockquote>{{/wms_tidal}}{{#wms_nodata}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>limited good quality satellite observations</b> in this location. This can reduce the quality of resulting coastline features.</blockquote>{{/wms_nodata}}</h3><i>For more information about coastline mapping accuracy and limitations or to download data, view the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines#details'>DEA Coastlines product description.</a></i></br></br>{{/year}}</div>"
+					  }
+				  },
+				  {
+					 "name":"Supplementary layers",
+					 "type":"group",
+					 "preserveOrder":true,
+					 "items":[
+						{
+						   "type":"wms",
+						   "name":"Annual coastlines",
+						   "id": "dea_coastlines_annual2",
+						   "url":"https://geoserver.dea.ga.gov.au/geoserver/wms",
+						   "opacity":"1.0",
+						   "layers":"dea:AnnualCoastlines",
+						   "shortReport":"<i>Zoom in to view individual annual coastlines from 1988 to the present</i></br></br><small>For more information and to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description</a></small>",
+						   "legendUrl":"https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_legend 1.png",
+						   "featureInfoTemplate":{
+							"template": "<div style='width:480px'><h2 style='font-weight:normal'>{{year}} annual coastline</h2>This line represents the approximate <b>median</b> (i.e. 'typical') position of the coastline at <b>0 m Above Mean Sea Level</b> across the entire of {{year}}.</br></br><h3 style='font-weight:normal'>{{#wms_aero}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>aerosol issues</b> caused by the 1991 eruption of Mount Pinatubo.</blockquote>{{/wms_aero}}{{#wms_tidal}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>tidal modelling issues</b>, potentially caused by errors in the tidal model used to constrain coastlines to mean sea level, or the influence of shallow intertidal topography that can lead to inaccurate coastline mapping.</blockquote>{{/wms_tidal}}{{#wms_nodata}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>limited good quality satellite observations</b> in this location. This can reduce the quality of resulting coastline features.</blockquote>{{/wms_nodata}}</h3><i>For more information about coastline mapping accuracy and limitations or to download data, view the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines#details'>DEA Coastlines product description.</a></i></br></br></div>"
+						  }
+						},
+						{
+						   "type":"wms",
+						   "name":"Rates of change statistics",
+						   "id": "dea_coastlines_statistics2",
+						   "url":"https://geoserver.dea.ga.gov.au/geoserver/wms",
+						   "opacity":"1.0",
+						   "layers":"dea:RateOfChangeStatistics",
+						   "shortReport":"<i>Zoom in to view detailed rates of coastal change along the Australian coastline</i></br></br><small>For more information and to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description</a></small>",
+						   "legendUrl":"https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_legend 1.png",
+						   "chartDisclaimer":"The graph below shows the distance (in metres) from each 1988-2018 coastline to the 2019 coastline. Positive distances indicate that a coastline was located towards the ocean from the 2019 coastline; coastlines with negative distances were located further inland.",
+						   "featureInfoTemplate":{
+							"template": "<div style='width:480px'><h2 style='font-weight:normal'>This coastline has <b>{{#retreat}}retreated &darr;{{/retreat}}{{#growth}}grown &uarr;{{/growth}}</b> by</br> <b>{{#terria.formatNumber}}{maximumFractionDigits:1}{{rate_time}}{{/terria.formatNumber}} metres (±{{#terria.formatNumber}}{maximumFractionDigits:1}{{conf_time}}{{/terria.formatNumber}}) per year</b></br>on average since <b>1988</b></h2>The coastline at this location was <b>most seaward in {{max_year}}</b>, and <b>most landward in {{min_year}}</b>{{#outl_time}} (excluding outlier years; see below){{/outl_time}}. Since 1988, the coastline has moved over a total distance of approximately <b>{{#terria.formatNumber}}{maximumFractionDigits:0}{{sce}}{{/terria.formatNumber}} metres.</b></br></br><chart title='DEA Coastlines ({{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.latitude}}{{/terria.formatNumber}}, {{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.longitude}}{{/terria.formatNumber}})' y-column='Distance (metres) relative to 2019 coastline' x-column='Year' column-units='{{terria.timeSeries.units}}' preview-x-label='Year'>Year,Distance (metres) relative to 2019 coastline\n1988,{{dist_1988}}\n1989,{{dist_1989}}\n1990,{{dist_1990}}\n1991,{{dist_1991}}\n1992,{{dist_1992}}\n1993,{{dist_1993}}\n1994,{{dist_1994}}\n1995,{{dist_1995}}\n1996,{{dist_1996}}\n1997,{{dist_1997}}\n1998,{{dist_1998}}\n1999,{{dist_1999}}\n2000,{{dist_2000}}\n2001,{{dist_2001}}\n2002,{{dist_2002}}\n2003,{{dist_2003}}\n2004,{{dist_2004}}\n2005,{{dist_2005}}\n2006,{{dist_2006}}\n2007,{{dist_2007}}\n2008,{{dist_2008}}\n2009,{{dist_2009}}\n2010,{{dist_2010}}\n2011,{{dist_2011}}\n2012,{{dist_2012}}\n2013,{{dist_2013}}\n2014,{{dist_2014}}\n2015,{{dist_2015}}\n2016,{{dist_2016}}\n2017,{{dist_2017}}\n2018,{{dist_2018}}\n2019,{{dist_2019}}</chart>{{#outl_time}}The following years were identified as potential outliers, and should be interpreted with caution:</br></br><b>{{outl_time}}</b></br>{{/outl_time}}<i></br>For more information about the DEA Coastlines coastal change statistics or to download data, view the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description.</a></i></br></br></div>"
+						  }
+						}
+					 ]
+				  }
+			   ]
+			},
             {
                "name": "Intertidal extent model",
                "type": "group",

--- a/dev/terria/dea-maps.json
+++ b/dev/terria/dea-maps.json
@@ -1020,7 +1020,7 @@
 				  {
 					 "type":"wms",
 					 "name":"Digital Earth Australia Coastlines",
-					 "id": "dea_coastlines2",
+					 "id": "dea_coastlines",
 					 "url":"https://geoserver.dea.ga.gov.au/geoserver/wms",
 					 "opacity":"1.0",
 					 "layers":"dea:DEACoastLines",
@@ -1039,7 +1039,7 @@
 						{
 						   "type":"wms",
 						   "name":"Annual coastlines",
-						   "id": "dea_coastlines_annual2",
+						   "id": "dea_coastlines_annual",
 						   "url":"https://geoserver.dea.ga.gov.au/geoserver/wms",
 						   "opacity":"1.0",
 						   "layers":"dea:AnnualCoastlines",
@@ -1052,7 +1052,7 @@
 						{
 						   "type":"wms",
 						   "name":"Rates of change statistics",
-						   "id": "dea_coastlines_statistics2",
+						   "id": "dea_coastlines_statistics",
 						   "url":"https://geoserver.dea.ga.gov.au/geoserver/wms",
 						   "opacity":"1.0",
 						   "layers":"dea:RateOfChangeStatistics",


### PR DESCRIPTION
This PR adds the updated DEA Coastlines config to the current version 7 of Terria on DEA Maps. This is a backup in case version 8 of Terria is not stood up prior to tomorrow's release.

@GypsyBojangles @pindge If you get a chance, it would be great if this PR could be reviewed as a priority so we have time to verify it works correctly. Thankyou! 