### PR TITLE
set tile_size for ls[]_fc_albers products

### DIFF
--- a/products/fc/ls5_fc_albers.yaml
+++ b/products/fc/ls5_fc_albers.yaml
@@ -18,6 +18,9 @@ storage:
           x: 25
           y: -25
   dimension_order: ['time', 'y', 'x']
+  tile_size:
+    x: 100000.0
+    y: 100000.0
 
 measurements:
     - name: BS

--- a/products/fc/ls7_fc_albers.yaml
+++ b/products/fc/ls7_fc_albers.yaml
@@ -18,6 +18,9 @@ storage:
           x: 25
           y: -25
   dimension_order: ['time', 'y', 'x']
+  tile_size:
+    x: 100000.0
+    y: 100000.0
 
 measurements:
     - name: BS

--- a/products/fc/ls8_fc_albers.yaml
+++ b/products/fc/ls8_fc_albers.yaml
@@ -18,6 +18,9 @@ storage:
           x: 25
           y: -25
   dimension_order: ['time', 'y', 'x']
+  tile_size:
+    x: 100000.0
+    y: 100000.0
 
 measurements:
     - name: BS


### PR DESCRIPTION
The (gridded) Landsat Fractional Cover product definitions are missing the `tile_size` information. This info is available for example in a very similar [wofs](https://github.com/GeoscienceAustralia/dea-config/blob/master/products/wofs/wofs_summary.yaml) definition.

This has recently popped us disguised as a WPS bug
- https://github.com/opendatacube/datacube-wps/issues/111
- https://github.com/opendatacube/datacube-core/issues/1152

My personal preference is to also relax `GridSpec` object construction in core, but that's not to say that these product definitions are not incomplete.
