### PR TITLE
Update DEA Maps groups for consistency with website/CMI

### DIFF
--- a/dev/terria/dea-maps-v8.json
+++ b/dev/terria/dea-maps-v8.json
@@ -4,7 +4,7 @@
         {
             "id": "CqkxcG",
             "type": "group",
-            "name": "Satellite data",
+            "name": "Baseline satellite data",
             "members": [
                 {
                     "type": "wms",
@@ -462,7 +462,7 @@
                     ]
                 }
             ],
-            "shareKeys": ["Root Group/Satellite data"]
+            "shareKeys": ["Root Group/Satellite images", "Root Group/Satellite data", "Root Group/Baseline satellite data"]
         },
         {
             "id": "ahjVXr",
@@ -770,7 +770,7 @@
         {
             "id": "dn823X",
             "type": "group",
-            "name": "Inland waterbodies",
+            "name": "Inland water",
             "members": [
                 {
                     "id": "3iIq5b",
@@ -1154,12 +1154,12 @@
                     ]
                 }
             ],
-            "shareKeys": ["Root Group/Surface Water"]
+            "shareKeys": ["Root Group/Surface Water", "Root Group/Inland waterbodies", "Root Group/Inland water"]
         },
         {
             "id": "D7zEZL",
             "type": "group",
-            "name": "Sea, ocean and coastline",
+            "name": "Sea, ocean and coast",
             "members": [
                 {
                     "id": "dkjsia",
@@ -1459,7 +1459,7 @@
                     ]
                 }
             ],
-            "shareKeys": ["Root Group/Coastal"]
+            "shareKeys": ["Root Group/Coastal", "Root Group/Sea, ocean and coastline", "Root Group/Sea, ocean and coast"]
         },
         {
             "id": "UIOgdf",


### PR DESCRIPTION
This PR makes three minor changes to the current DEA Maps groups for consistency with CMI and the DEA Website:

"Satellite data" > "Baseline satellite data"
"Inland waterbodies" > "Inland water"
"Sea, ocean and coastline" > "Sea, ocean and coast"

For all these changes, I have added the old names to `shareKeys` which should give us backwards compatability.

Tested on DEA Maps, all works as expected.



e.g. 
![image](https://user-images.githubusercontent.com/17680388/130888198-76f27ad7-2524-4639-b261-68d28ed172bc.png)
![image](https://user-images.githubusercontent.com/17680388/130888221-fc9f8119-b34f-4880-8523-2059ccdf34f8.png)
![image](https://user-images.githubusercontent.com/17680388/130888271-45438252-9fc9-4234-b988-4e06e808e442.png)
