### PR TITLE
Resolve error with output platform field

### DIFF
--- a/dev/services/alchemist/s2_nrt_bs/s2_c3_nrt_ba_provisional.alchemist.yaml
+++ b/dev/services/alchemist/s2_nrt_bs/s2_c3_nrt_ba_provisional.alchemist.yaml
@@ -35,7 +35,6 @@ output:
   properties:
     dea:dataset_maturity: interim
     dea:product_maturity: provisional
-    eo:platform: sentinel-2
     eo:instrument: MSI
     odc:file_format: GeoTIFF
 


### PR DESCRIPTION
Removed platform property due to the below error.

```
2021-09-03 05:20:20 [info     ] Loaded and transformed         task=UUID('6438c322-412b-4e41-b1a7-435e5e07b91d')
/usr/local/lib/python3.8/dist-packages/eodatasets3/properties.py:431: PropertyOverrideWarning: Overriding property 'sentinel:datatake_start_datetime' (from '2021-09-02 03:36:20Z' to datetime.datetime(2021, 9, 2, 3, 36, 20, tzinfo=datetime.timezone.utc))
  warnings.warn(message, category=PropertyOverrideWarning)
/usr/local/lib/python3.8/dist-packages/eodatasets3/properties.py:431: PropertyOverrideWarning: Overriding property 'eo:platform' (from 'sentinel-2b' to 'sentinel-2')
  warnings.warn(message, category=PropertyOverrideWarning)
/usr/local/lib/python3.8/dist-packages/datacube/utils/geometry/_base.py:305: DeprecationWarning: Please use `str(crs)` instead of `crs.crs_str`
  warnings.warn("Please use `str(crs)` instead of `crs.crs_str`", category=DeprecationWarning)
/usr/local/lib/python3.8/dist-packages/eodatasets3/assemble.py:1191: UserWarning: Closing assembler without finishing. Either call `done()` or `cancel() before closing`
  warnings.warn(
Traceback (most recent call last):
  File "/usr/local/bin/datacube-alchemist", line 8, in <module>
    sys.exit(cli_with_envvar_handling())
  File "/usr/local/lib/python3.8/dist-packages/datacube_alchemist/cli.py", line 67, in cli_with_envvar_handling
    cli(auto_envvar_prefix="ALCHEMIST")
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/datacube_alchemist/cli.py", line 94, in run_one
    alchemist.execute_task(task, dryrun)
  File "/usr/local/lib/python3.8/dist-packages/datacube_alchemist/worker.py", line 503, in execute_task
    dataset_assembler.write_measurements_odc_xarray(
  File "/usr/local/lib/python3.8/dist-packages/eodatasets3/assemble.py", line 1345, in write_measurements_odc_xarray
    / self.names.measurement_filename(name, "tif", file_id=file_id)
  File "/usr/local/lib/python3.8/dist-packages/eodatasets3/names.py", line 709, in measurement_filename
    return self.filename(
  File "/usr/local/lib/python3.8/dist-packages/eodatasets3/names.py", line 724, in filename
    return self.filename_pattern.format(file_id=file_id, suffix=suffix, n=self)
  File "/usr/local/lib/python3.8/dist-packages/eodatasets3/names.py", line 79, in __get__
    product_prefix = c.product_name
  File "/usr/local/lib/python3.8/dist-packages/eodatasets3/names.py", line 39, in __get__
    f"{c.platform_abbreviated or ''}{instrument or ''}",
  File "/usr/local/lib/python3.8/dist-packages/eodatasets3/names.py", line 153, in __get__
    raise ValueError(
ValueError: We don't know the DEA abbreviation for platforms {'sentinel-2'}. We'd love to add more! Raise an issue on Github: https://github.com/GeoscienceAustralia/eo-datasets/issues/new'
```