### PR TITLE
Update the FCP config files

### DIFF
--- a/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3 .yaml
+++ b/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3 .yaml
@@ -1,7 +1,7 @@
 plugin: fc-percentiles # this can help system find the relative plugin and plugin version
 product:
-  name: fc_percentile
-  short_name: fc_percentile
+  name: ga_ls_fc_pc_cyear_3
+  short_name: ga_ls_fc_pc_cyear_3
   version: 1.6.0
   product_family: fc_percentile
 
@@ -69,7 +69,3 @@ s3_acl: public-read
 # Generic product attributes
 cog_opts:
   zlevel: 9
-  overrides:
-    rgba:
-      compress: JPEG
-      jpeg_quality: 90

--- a/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_fyear_3.yaml
+++ b/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_fyear_3.yaml
@@ -1,0 +1,71 @@
+plugin: fc-percentiles # this can help system find the relative plugin and plugin version
+product:
+  name: ga_ls_fc_pc_fyear_3
+  short_name: ga_ls_fc_pc_fyear_3
+  version: 1.6.0
+  product_family: fc_percentile
+
+  # -- EO Dataset3 relative section --
+  naming_conventions_values: dea_c3
+  explorer_path: https://explorer.dea.ga.gov.au/
+  classifier: ard
+  maturity: final
+  collection_number: 3
+
+  inherit_skip_properties:
+    - eo:cloud_cover
+    - fmask:clear
+    - fmask:snow
+    - fmask:cloud
+    - fmask:water
+    - fmask:cloud_shadow
+    - eo:sun_elevation
+    - eo:sun_azimuth
+    - gqa:iterative_stddev_x
+    - gqa:iterative_stddev_y
+    - gqa:iterative_stddev_xy
+    - gqa:stddev_xy
+    - gqa:stddev_x
+    - gqa:stddev_y
+    - gqa:mean_xy
+    - gqa:mean_x
+    - gqa:mean_y
+    - gqa:abs_xy
+    - gqa:abs_x
+    - gqa:abs_y
+    - gqa:abs_iterative_mean_y
+    - gqa:abs_iterative_mean_x
+    - gqa:abs_iterative_mean_xy
+    - gqa:iterative_mean_xy
+    - gqa:iterative_mean_x
+    - gqa:iterative_mean_y
+    - gqa:cep90
+    - landsat:landsat_product_id
+    - landsat:landsat_scene_id
+
+  preview_image_ows_style:
+    name: fc_rgb
+    title: Three-band fractional cover
+    abstract: Fractional cover medians - red is bare soil, green is green vegetation and
+      blue is non-green vegetation
+    components:
+      red:
+        bs_pc_50: 1
+      green:
+        pv_pc_50: 1
+      blue:
+        npv_pc_50: 1
+    scale_range:
+    - 0
+    - 100
+
+aws_unsigned: True
+
+max_processing_time: 1200
+job_queue_max_lease: 300
+renew_safety_margin: 60
+future_poll_interval: 2
+s3_acl: public-read
+# Generic product attributes
+cog_opts:
+  zlevel: 9


### PR DESCRIPTION
The FC Percentiles has two products.

1) Fractional Cover Percentiles Calendar Year (Landsat) -> ga_ls_fc_pc_cyear_3
2) Fractional Cover Percentiles Financial Year (Landsat) -> ga_ls_fc_pc_fyear_3

Therefore, we have two different config files to run odc-stats.
