### PR TITLE
Update DEA Maps with Terria changes

### DIFF
--- a/dev/terria/dea-maps-v8.json
+++ b/dev/terria/dea-maps-v8.json
@@ -1,456 +1,37 @@
 {
     "workbench": [],
     "catalog": [
-        {
-            "id": "CqkxcG",
-            "type": "group",
-            "name": "Baseline satellite data",
-            "members": [
                 {
-                    "type": "wms",
-                    "name": "DEA Surface Reflectance (Landsat and Sentinel-2)",
-                    "url": "https://gsky.nci.org.au/ows/dea",
-                    "opacity": 1,
-                    "layers": "blend_sentinel2_landsat_nbart_daily",
-                    "chartColor": "white",
-                    "timeFilterPropertyName": "data_available_for_dates",
-                    "leafletUpdateInterval": 750,
-                    "chartType": "momentPoints",
-                    "tileErrorHandlingOptions": {
-                        "ignoreUnknownTileErrors": true
-                    },
-                    "id": "Wqpk8F",
-                    "shareKeys": [
-                        "Root Group/Satellite images/Satellite images multi-sensor - daily/Daily Landsat and Sentinel-2 satellite images"
-                    ]
-                },
-                {
-                    "type": "wms",
-                    "name": "DEA Surface Reflectance (Landsat)",
-                    "url": "https://ows.dea.ga.gov.au/",
-                    "opacity": 1,
-                    "layers": "ga_ls_ard_3",
-                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                    "linkedWcsCoverage": "ga_ls_ard_3",
-                    "chartColor": "white",
-                    "timeFilterPropertyName": "data_available_for_dates",
-                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                    "leafletUpdateInterval": 750,
-                    "chartType": "momentPoints",
-                    "featureInfoTemplate": {
-                        "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Normalised Difference Vegetation Index</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>Normalised Difference Water Index</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>Modified Normalised Difference Water Index</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>Normalised Burn Ratio</b></td><td>{{data.0.band_derived.nbr}}</td></tr></table><p><chart id='{{x}}{{y}}{{time}}' title='NBART at {{x}},{{y}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n840,{{data.0.bands.nbart_nir}}\n1650,{{data.0.bands.nbart_swir1}}\n2220,{{data.0.bands.nbart_swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                        "formats": {
-                            "lat": {
-                                "maximumFractionDigits": 5
-                            },
-                            "lon": {
-                                "maximumFractionDigits": 5
-                            }
-                        }
-                    },
-                    "tileErrorHandlingOptions": {
-                        "ignoreUnknownTileErrors": true
-                    },
-                    "id": "8sfhio"
-                },
-                {
-                    "type": "wms",
-                    "name": "DEA Surface Reflectance (Sentinel-2) - near real time",
-                    "url": "https://ows.dea.ga.gov.au/",
-                    "opacity": 1,
-                    "layers": "s2_nrt_granule_nbar_t",
-                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                    "linkedWcsCoverage": "s2_nrt_granule_nbar_t",
-                    "chartColor": "white",
-                    "timeFilterPropertyName": "data_available_for_dates",
-                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                    "leafletUpdateInterval": 750,
-                    "chartType": "momentPoints",
-                    "featureInfoTemplate": {
-                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{data.0.bands.nbart_coastal_aerosol}}\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n670,{{data.0.bands.nbart_red}}\n710,{{data.0.bands.nbart_red_edge_1}}\n740,{{data.0.bands.nbart_red_edge_2}}\n780,{{data.0.bands.nbart_red_edge_3}}\n840,{{data.0.bands.nbart_nir_1}}\n870,{{data.0.bands.nbart_nir_2}}\n1610,{{data.0.bands.nbart_swir_2}}\n2190,{{data.0.bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                        "formats": {
-                            "lat": {
-                                "maximumFractionDigits": 5
-                            },
-                            "lon": {
-                                "maximumFractionDigits": 5
-                            }
-                        }
-                    },
-                    "tileErrorHandlingOptions": {
-                        "ignoreUnknownTileErrors": true
-                    },
-                    "id": "Z1RRRa",
-                    "shareKeys": [
-                        "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 90-day expedited satellite images/Expedited Sentinel 2 satellite images"
-                    ]
-                },
-                {
-                    "type": "wms",
-                    "name": "DEA Surface Reflectance (Sentinel-2)",
-                    "url": "https://ows.dea.ga.gov.au/",
-                    "opacity": 1,
-                    "layers": "s2_ard_granule_nbar_t",
-                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                    "linkedWcsCoverage": "s2_ard_granule_nbar_t",
-                    "chartColor": "white",
-                    "timeFilterPropertyName": "data_available_for_dates",
-                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                    "leafletUpdateInterval": 750,
-                    "chartType": "momentPoints",
-                    "featureInfoTemplate": {
-                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbar_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbar_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbar_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbar_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbar_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbar_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbar_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbar_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbar_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbar_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbar_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBAR at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBAR Reflectance'>nm,NBAR Reflectance\n440,{{data.0.bands.nbar_coastal_aerosol}}\n490,{{data.0.bands.nbar_blue}}\n560,{{data.0.bands.nbar_green}}\n670,{{data.0.bands.nbar_red}}\n710,{{data.0.bands.nbar_red_edge_1}}\n740,{{data.0.bands.nbar_red_edge_2}}\n780,{{data.0.bands.nbar_red_edge_3}}\n840,{{data.0.bands.nbar_nir_1}}\n870,{{data.0.bands.nbar_nir_2}}\n1610,{{data.0.bands.nbar_swir_2}}\n2190,{{data.0.bands.nbar_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                        "formats": {
-                            "lat": {
-                                "maximumFractionDigits": 5
-                            },
-                            "lon": {
-                                "maximumFractionDigits": 5
-                            }
-                        }
-                    },
-                    "tileErrorHandlingOptions": {
-                        "ignoreUnknownTileErrors": true
-                    },
-                    "id": "SbBCvf",
-                    "shareKeys": [
-                        "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 satellite imagery archive/Sentinel 2 satellite images"
-                    ]
-                },
-                {
-                    "id": "x7b8dq",
+                    "id": "CqkxcG",
                     "type": "group",
-                    "name": "Sentinel-2 satellite images",
+                    "name": "Baseline satellite data",
                     "members": [
                         {
                             "type": "wms",
-                            "name": "DEA Surface Reflectance (Sentinel-2A MSI) - near real time",
-                            "url": "https://ows.dea.ga.gov.au/",
+                            "name": "DEA Surface Reflectance (Landsat and Sentinel-2)",
+                            "url": "https://gsky.nci.org.au/ows/dea",
                             "opacity": 1,
-                            "layers": "s2a_nrt_granule_nbar_t",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "s2a_nrt_granule_nbar_t",
+                            "layers": "blend_sentinel2_landsat_nbart_daily",
                             "chartColor": "white",
                             "timeFilterPropertyName": "data_available_for_dates",
-                            "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
                             "leafletUpdateInterval": 750,
                             "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{data.0.bands.nbart_coastal_aerosol}}\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n670,{{data.0.bands.nbart_red}}\n710,{{data.0.bands.nbart_red_edge_1}}\n740,{{data.0.bands.nbart_red_edge_2}}\n780,{{data.0.bands.nbart_red_edge_3}}\n840,{{data.0.bands.nbart_nir_1}}\n870,{{data.0.bands.nbart_nir_2}}\n1610,{{data.0.bands.nbart_swir_2}}\n2190,{{data.0.bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
                             "tileErrorHandlingOptions": {
                                 "ignoreUnknownTileErrors": true
                             },
-                            "id": "8apTli",
+                            "id": "Wqpk8F",
                             "shareKeys": [
-                                "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 90-day expedited satellite images/Expedited Sentinel 2A satellite images"
+                                "Root Group/Satellite images/Satellite images multi-sensor - daily/Daily Landsat and Sentinel-2 satellite images"
                             ]
                         },
                         {
                             "type": "wms",
-                            "name": "DEA Surface Reflectance (Sentinel-2B MSI) - near real time",
+                            "name": "DEA Surface Reflectance (Landsat)",
                             "url": "https://ows.dea.ga.gov.au/",
                             "opacity": 1,
-                            "layers": "s2b_nrt_granule_nbar_t",
+                            "layers": "ga_ls_ard_3",
                             "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "s2b_nrt_granule_nbar_t",
-                            "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                            "chartColor": "white",
-                            "timeFilterPropertyName": "data_available_for_dates",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{data.0.bands.nbart_coastal_aerosol}}\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n670,{{data.0.bands.nbart_red}}\n710,{{data.0.bands.nbart_red_edge_1}}\n740,{{data.0.bands.nbart_red_edge_2}}\n780,{{data.0.bands.nbart_red_edge_3}}\n840,{{data.0.bands.nbart_nir_1}}\n870,{{data.0.bands.nbart_nir_2}}\n1610,{{data.0.bands.nbart_swir_2}}\n2190,{{data.0.bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "AuD7kv",
-                            "shareKeys": [
-                                "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 90-day expedited satellite images/Expedited Sentinel 2B satellite images"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance (Sentinel-2A MSI)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "s2a_ard_granule_nbar_t",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "s2a_ard_granule_nbar_t",
-                            "chartColor": "white",
-                            "timeFilterPropertyName": "data_available_for_dates",
-                            "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbar_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbar_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbar_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbar_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbar_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbar_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbar_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbar_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbar_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbar_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbar_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBAR at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBAR Reflectance'>nm,NBAR Reflectance\n440,{{data.0.bands.nbar_coastal_aerosol}}\n490,{{data.0.bands.nbar_blue}}\n560,{{data.0.bands.nbar_green}}\n670,{{data.0.bands.nbar_red}}\n710,{{data.0.bands.nbar_red_edge_1}}\n740,{{data.0.bands.nbar_red_edge_2}}\n780,{{data.0.bands.nbar_red_edge_3}}\n840,{{data.0.bands.nbar_nir_1}}\n870,{{data.0.bands.nbar_nir_2}}\n1610,{{data.0.bands.nbar_swir_2}}\n2190,{{data.0.bands.nbar_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "iNJKMD",
-                            "shareKeys": [
-                                "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 satellite imagery archive/Sentinel 2a satellite images"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance (Sentinel-2B MSI)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "s2b_ard_granule_nbar_t",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "s2b_ard_granule_nbar_t",
-                            "chartColor": "white",
-                            "timeFilterPropertyName": "data_available_for_dates",
-                            "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbar_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbar_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbar_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbar_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbar_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbar_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbar_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbar_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbar_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbar_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbar_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBAR at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBAR Reflectance'>nm,NBAR Reflectance\n440,{{data.0.bands.nbar_coastal_aerosol}}\n490,{{data.0.bands.nbar_blue}}\n560,{{data.0.bands.nbar_green}}\n670,{{data.0.bands.nbar_red}}\n710,{{data.0.bands.nbar_red_edge_1}}\n740,{{data.0.bands.nbar_red_edge_2}}\n780,{{data.0.bands.nbar_red_edge_3}}\n840,{{data.0.bands.nbar_nir_1}}\n870,{{data.0.bands.nbar_nir_2}}\n1610,{{data.0.bands.nbar_swir_2}}\n2190,{{data.0.bands.nbar_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "RACNHJ",
-                            "shareKeys": [
-                                "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 satellite imagery archive/Sentinel 2b satellite images"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance (Sentinel-2) (Provisional)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "s2_nrt_provisional_granule_nbar_t",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "s2_nrt_provisional_granule_nbar_t",
-                            "chartColor": "white",
-                            "timeFilterPropertyName": "data_available_for_dates",
-                            "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{data.0.bands.nbart_coastal_aerosol}}\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n670,{{data.0.bands.nbart_red}}\n710,{{data.0.bands.nbart_red_edge_1}}\n740,{{data.0.bands.nbart_red_edge_2}}\n780,{{data.0.bands.nbart_red_edge_3}}\n840,{{data.0.bands.nbart_nir_1}}\n870,{{data.0.bands.nbart_nir_2}}\n1610,{{data.0.bands.nbart_swir_2}}\n2190,{{data.0.bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "IUTY45"
-                        },
-                        {
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance (Sentinel-2A MSI) (Provisional)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "s2a_nrt_provisional_granule_nbar_t",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "s2a_nrt_provisional_granule_nbar_t",
-                            "chartColor": "white",
-                            "timeFilterPropertyName": "data_available_for_dates",
-                            "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{data.0.bands.nbart_coastal_aerosol}}\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n670,{{data.0.bands.nbart_red}}\n710,{{data.0.bands.nbart_red_edge_1}}\n740,{{data.0.bands.nbart_red_edge_2}}\n780,{{data.0.bands.nbart_red_edge_3}}\n840,{{data.0.bands.nbart_nir_1}}\n870,{{data.0.bands.nbart_nir_2}}\n1610,{{data.0.bands.nbart_swir_2}}\n2190,{{data.0.bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "SDF32t"
-                        },
-                        {
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance (Sentinel-2B MSI) (Provisional)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "s2b_nrt_provisional_granule_nbar_t",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "s2b_nrt_provisional_granule_nbar_t",
-                            "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                            "chartColor": "white",
-                            "timeFilterPropertyName": "data_available_for_dates",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{data.0.bands.nbart_coastal_aerosol}}\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n670,{{data.0.bands.nbart_red}}\n710,{{data.0.bands.nbart_red_edge_1}}\n740,{{data.0.bands.nbart_red_edge_2}}\n780,{{data.0.bands.nbart_red_edge_3}}\n840,{{data.0.bands.nbart_nir_1}}\n870,{{data.0.bands.nbart_nir_2}}\n1610,{{data.0.bands.nbart_swir_2}}\n2190,{{data.0.bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "fgh369"
-                        }
-                    ],
-                    "shareKeys": [
-                        "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 satellite imagery archive"
-                    ]
-                },
-                {
-                    "id": "aN8xKz",
-                    "type": "group",
-                    "name": "Landsat satellite images",
-                    "members": [
-                        {
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance (Landsat 8 OLI-TIRS)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ga_ls8c_ard_3",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ga_ls8c_ard_3",
-                            "chartColor": "white",
-                            "timeFilterPropertyName": "data_available_for_dates",
-                            "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n870,{{data.0.bands.nbart_nir}}\n1610,{{data.0.bands.nbart_swir_1}}\n2200,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "5k8KR4",
-                            "shareKeys": [
-                                "Root Group/Satellite images/Satellite images 25m - daily/Daily Landsat 8 satellite images"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance (Landst 7 ETM+)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ga_ls7e_ard_3",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ga_ls7e_ard_3",
-                            "chartColor": "white",
-                            "timeFilterPropertyName": "data_available_for_dates",
-                            "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n840,{{data.0.bands.nbart_nir}}\n1650,{{data.0.bands.nbart_swir_1}}\n2220,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "bzDSiT",
-                            "shareKeys": [
-                                "Root Group/Satellite images/Satellite images 25m - daily/Daily Landsat 7 satellite images"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance (Landsat 5 TM)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ga_ls5t_ard_3",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ga_ls5t_ard_3",
-                            "chartColor": "white",
-                            "timeFilterPropertyName": "data_available_for_dates",
-                            "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n840,{{data.0.bands.nbart_nir}}\n1650,{{data.0.bands.nbart_swir_1}}\n2220,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "rESkby",
-                            "shareKeys": [
-                                "Root Group/Satellite images/Satellite images 25m - daily/Daily Landsat 5 satellite images"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance (Landsat) (Provisional)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ga_ls_ard_provisional_3",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ga_ls_ard_provisional_3",
+                            "linkedWcsCoverage": "ga_ls_ard_3",
                             "chartColor": "white",
                             "timeFilterPropertyName": "data_available_for_dates",
                             "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
@@ -470,23 +51,23 @@
                             "tileErrorHandlingOptions": {
                                 "ignoreUnknownTileErrors": true
                             },
-                            "id": "98SDFs"
+                            "id": "8sfhio"
                         },
                         {
                             "type": "wms",
-                            "name": "DEA Surface Reflectance (Landsat 8 OLI-TIRS) (Provisional)",
+                            "name": "DEA Surface Reflectance (Sentinel-2 Near Real Time)",
                             "url": "https://ows.dea.ga.gov.au/",
                             "opacity": 1,
-                            "layers": "ga_ls8c_ard_provisional_3",
+                            "layers": "s2_nrt_granule_nbar_t",
                             "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ga_ls8c_ard_provisional_3",
+                            "linkedWcsCoverage": "s2_nrt_granule_nbar_t",
                             "chartColor": "white",
                             "timeFilterPropertyName": "data_available_for_dates",
                             "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
                             "leafletUpdateInterval": 750,
                             "chartType": "momentPoints",
                             "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n870,{{data.0.bands.nbart_nir}}\n1610,{{data.0.bands.nbart_swir_1}}\n2200,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{data.0.bands.nbart_coastal_aerosol}}\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n670,{{data.0.bands.nbart_red}}\n710,{{data.0.bands.nbart_red_edge_1}}\n740,{{data.0.bands.nbart_red_edge_2}}\n780,{{data.0.bands.nbart_red_edge_3}}\n840,{{data.0.bands.nbart_nir_1}}\n870,{{data.0.bands.nbart_nir_2}}\n1610,{{data.0.bands.nbart_swir_2}}\n2190,{{data.0.bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
                                 "formats": {
                                     "lat": {
                                         "maximumFractionDigits": 5
@@ -499,23 +80,26 @@
                             "tileErrorHandlingOptions": {
                                 "ignoreUnknownTileErrors": true
                             },
-                            "id": "dfsRY4"
+                            "id": "Z1RRRa",
+                            "shareKeys": [
+                                "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 90-day expedited satellite images/Expedited Sentinel 2 satellite images"
+                            ]
                         },
                         {
                             "type": "wms",
-                            "name": "DEA Surface Reflectance (Landst 7 ETM+) (Provisional)",
+                            "name": "DEA Surface Reflectance (Sentinel-2)",
                             "url": "https://ows.dea.ga.gov.au/",
                             "opacity": 1,
-                            "layers": "ga_ls7e_ard_provisional_3",
+                            "layers": "s2_ard_granule_nbar_t",
                             "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ga_ls7e_ard_provisional_3",
+                            "linkedWcsCoverage": "s2_ard_granule_nbar_t",
                             "chartColor": "white",
                             "timeFilterPropertyName": "data_available_for_dates",
                             "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
                             "leafletUpdateInterval": 750,
                             "chartType": "momentPoints",
                             "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n840,{{data.0.bands.nbart_nir}}\n1650,{{data.0.bands.nbart_swir_1}}\n2220,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbar_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbar_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbar_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbar_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbar_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbar_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbar_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbar_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbar_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbar_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbar_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBAR at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBAR Reflectance'>nm,NBAR Reflectance\n440,{{data.0.bands.nbar_coastal_aerosol}}\n490,{{data.0.bands.nbar_blue}}\n560,{{data.0.bands.nbar_green}}\n670,{{data.0.bands.nbar_red}}\n710,{{data.0.bands.nbar_red_edge_1}}\n740,{{data.0.bands.nbar_red_edge_2}}\n780,{{data.0.bands.nbar_red_edge_3}}\n840,{{data.0.bands.nbar_nir_1}}\n870,{{data.0.bands.nbar_nir_2}}\n1610,{{data.0.bands.nbar_swir_2}}\n2190,{{data.0.bands.nbar_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
                                 "formats": {
                                     "lat": {
                                         "maximumFractionDigits": 5
@@ -528,875 +112,1261 @@
                             "tileErrorHandlingOptions": {
                                 "ignoreUnknownTileErrors": true
                             },
-                            "id": "456FGw"
-                        }
-                    ],
-                    "shareKeys": [
-                        "Root Group/Satellite images/Satellite images 25m - daily"
-                    ]
-                },
-                {
-                    "id": "VEvPmu",
-                    "type": "group",
-                    "name": "Landsat satellite images - annual",
-                    "members": [
-                        {
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance Geomedian (Landsat 8 OLI-TIRS)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ls8_nbart_geomedian_annual",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ls8_nbart_geomedian_annual",
-                            "chartColor": "white",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{data.0.bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{data.0.bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{data.0.bands.blue}}\n560,{{data.0.bands.green}}\n660,{{data.0.bands.red}}\n870,{{data.0.bands.nir}}\n1610,{{data.0.bands.swir1}}\n2200,{{data.0.bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "hAUsXi",
+                            "id": "SbBCvf",
                             "shareKeys": [
-                                "Root Group/Satellite images/Satellite images 25m - annual/Yearly average Landsat 8 satellite images"
+                                "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 satellite imagery archive/Sentinel 2 satellite images"
                             ]
                         },
                         {
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance Geomedian (Landsat 7 ETM+)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ls7_nbart_geomedian_annual",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ls7_nbart_geomedian_annual",
-                            "chartColor": "white",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.blue}}\n560,{{data.0.bands.green}}\n660,{{data.0.bands.red}}\n840,{{data.0.bands.nir}}\n1650,{{data.0.bands.swir1}}\n2220,{{data.0.bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "pwDY6b",
-                            "shareKeys": [
-                                "Root Group/Satellite images/Satellite images 25m - annual/Yearly average Landsat 7 satellite images"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance Geomedian (Landsat 5 TM)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ls5_nbart_geomedian_annual",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ls5_nbart_geomedian_annual",
-                            "chartColor": "white",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.blue}}\n560,{{data.0.bands.green}}\n660,{{data.0.bands.red}}\n840,{{data.0.bands.nir}}\n1650,{{data.0.bands.swir1}}\n2220,{{data.0.bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "BpKM2u",
-                            "shareKeys": [
-                                "Root Group/Satellite images/Satellite images 25m - annual/Yearly average Landsat 5 satellite images"
-                            ]
-                        }
-                    ],
-                    "shareKeys": [
-                        "Root Group/Satellite images/Satellite images 25m - annual"
-                    ]
-                }
-            ],
-            "shareKeys": ["Root Group/Satellite images", "Root Group/Satellite data", "Root Group/Baseline satellite data"]
-        },
-        {
-            "id": "ahjVXr",
-            "type": "group",
-            "name": "Land and vegetation",
-            "members": [
-                {
-                    "id": "irRsX3",
-                    "type": "group",
-                    "name": "DEA Fractional Cover",
-                    "members": [
-                        {
-                            "type": "wms",
-                            "name": "DEA Fractional Cover (Landsat)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ga_ls_fc_3",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ga_ls_fc_3",
-                            "chartColor": "white",
-                            "timeFilterPropertyName": "data_available_for_dates",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "mYnkqY",
-                            "shareKeys": [
-                                "Root Group/Vegetation/Fractional Cover/Daily Fractional Cover observations"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "Seasonal Fractional Cover",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "fcp_seasonal_rgb",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "fcp_seasonal_rgb",
-                            "chartColor": "white",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "8uKmJ8",
-                            "shareKeys": [
-                                "Root Group/Vegetation/Fractional Cover/Seasonal Fractional Cover"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "Annual Fractional Cover",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "fcp_rgb",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "fcp_rgb",
-                            "chartColor": "white",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "BLxe8I",
-                            "shareKeys": [
-                                "Root Group/Vegetation/Fractional Cover/Annual Fractional Cover"
-                            ]
-                        },
-                        {
-                            "id": "rTKE41",
+                            "id": "VEvPmu",
                             "type": "group",
-                            "name": "Seasonal Fractional Cover summaries",
+                            "name": "DEA Surface Reflectance Calendar Year (Landsat)",
                             "members": [
                                 {
                                     "type": "wms",
-                                    "name": "Seasonal Green Vegetation",
+                                    "name": "DEA Surface Reflectance Calendar Year (Landsat 8 OLI-TIRS)",
                                     "url": "https://ows.dea.ga.gov.au/",
                                     "opacity": 1,
-                                    "layers": "fcp_seasonal_green_veg",
+                                    "layers": "ls8_nbart_geomedian_annual",
                                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "fcp_seasonal_green_veg",
+                                    "linkedWcsCoverage": "ls8_nbart_geomedian_annual",
                                     "chartColor": "white",
                                     "leafletUpdateInterval": 750,
                                     "chartType": "momentPoints",
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "BL3iXJ",
-                                    "shareKeys": [
-                                        "Root Group/Vegetation/Fractional Cover/Seasonal Fractional Cover summaries/Seasonal Green Vegetation"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "Seasonal Non-Green Vegetation",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "fcp_seasonal_non_green_veg",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "fcp_seasonal_non_green_veg",
-                                    "chartColor": "white",
-                                    "leafletUpdateInterval": 750,
-                                    "chartType": "momentPoints",
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "uqGrkN",
-                                    "shareKeys": [
-                                        "Root Group/Vegetation/Fractional Cover/Seasonal Fractional Cover summaries/Seasonal Non-Green Vegetation"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "Seasonal Bare Ground",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "fcp_seasonal_bare_ground",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "fcp_seasonal_bare_ground",
-                                    "chartColor": "white",
-                                    "leafletUpdateInterval": 750,
-                                    "chartType": "momentPoints",
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "VScBTN",
-                                    "shareKeys": [
-                                        "Root Group/Vegetation/Fractional Cover/Seasonal Fractional Cover summaries/Seasonal Bare Ground"
-                                    ]
-                                }
-                            ],
-                            "shareKeys": [
-                                "Root Group/Vegetation/Fractional Cover/Seasonal Fractional Cover summaries"
-                            ]
-                        },
-                        {
-                            "id": "nI2Kfn",
-                            "type": "group",
-                            "name": "Annual Fractional Cover summaries",
-                            "members": [
-                                {
-                                    "type": "wms",
-                                    "name": "Annual Green Vegetation",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "fcp_green_veg",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "fcp_green_veg",
-                                    "chartColor": "white",
-                                    "leafletUpdateInterval": 750,
-                                    "chartType": "momentPoints",
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "7eJRQy",
-                                    "shareKeys": [
-                                        "Root Group/Vegetation/Fractional Cover/Annual Fractional Cover summaries/Annual Green Vegetation"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "Annual Non-Green Vegetation",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "fcp_non_green_veg",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "fcp_non_green_veg",
-                                    "chartColor": "white",
-                                    "leafletUpdateInterval": 750,
-                                    "chartType": "momentPoints",
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "uFlnzu",
-                                    "shareKeys": [
-                                        "Root Group/Vegetation/Fractional Cover/Annual Fractional Cover summaries/Annual Non-Green Vegetation"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "Annual Bare Ground",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "fcp_bare_ground",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "fcp_bare_ground",
-                                    "chartColor": "white",
-                                    "leafletUpdateInterval": 750,
-                                    "chartType": "momentPoints",
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "L1wwAP",
-                                    "shareKeys": [
-                                        "Root Group/Vegetation/Fractional Cover/Annual Fractional Cover summaries/Annual Bare Ground"
-                                    ]
-                                }
-                            ],
-                            "shareKeys": [
-                                "Root Group/Vegetation/Fractional Cover/Annual Fractional Cover summaries"
-                            ]
-                        }
-                    ],
-                    "shareKeys": ["Root Group/Vegetation/Fractional Cover"]
-                },
-                {
-                    "id": "462q3S",
-                    "type": "group",
-                    "name": "DEA Mangrove Canopy Cover",
-                    "members": [
-                        {
-                            "type": "wms",
-                            "name": "DEA Mangrove Canopy Cover",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "mangrove_cover_v2_0_2",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "mangrove_cover_v2_0_2",
-                            "chartColor": "white",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "3gjEXB",
-                            "shareKeys": [
-                                "Root Group/Vegetation/Mangrove Canopy Cover"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "id": "u8GXYD",
-                    "type": "group",
-                    "name": "Barest Earth",
-                    "members": [
-                        {
-                            "type": "wms",
-                            "name": "Barest Earth Landsat 8 satellite images",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ls8_barest_earth_mosaic",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ls8_barest_earth_mosaic",
-                            "chartColor": "white",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{data.0.bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{data.0.bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{data.0.bands.blue}}\n560,{{data.0.bands.green}}\n660,{{data.0.bands.red}}\n870,{{data.0.bands.nir}}\n1610,{{data.0.bands.swir1}}\n2200,{{data.0.bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "Mn56Pg",
-                            "shareKeys": [
-                                "Root Group/Satellite images/Satellite images 25m - Barest Earth/Barest Earth Landsat 8 satellite images"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "Landsat 30+ Barest Earth Satellite Images (Combined Landsat)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "landsat_barest_earth",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "landsat_barest_earth",
-                            "chartColor": "white",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "WRTIQP",
-                            "shareKeys": [
-                                "Root Group/Satellite images/Satellite images 25m - Barest Earth/Landsat 30+ Barest Earth Satellite Images (Combined Landsat)"
-                            ]
-                        }
-                    ],
-                    "shareKeys": [
-                        "Root Group/Satellite images/Satellite images 25m - Barest Earth"
-                    ]
-                }
-            ],
-            "shareKeys": ["Root Group/Vegetation"]
-        },
-        {
-            "id": "dn823X",
-            "type": "group",
-            "name": "Inland water",
-            "members": [
-                {
-                    "id": "3iIq5b",
-                    "type": "group",
-                    "name": "DEA Water Observations (WOfS)",
-                    "members": [
-                        {
-                            "type": "wms",
-                            "name": "DEA Water Observations (Landsat)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ga_ls_wo_3",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ga_ls_wo_3",
-                            "chartColor": "white",
-                            "timeFilterPropertyName": "data_available_for_dates",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "iun7iP",
-                            "shareKeys": [
-                                "Root Group/Surface Water/Water Observations from Space/Daily water observations"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "April-October water observations",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "wofs_apr_oct_summary_statistics",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "wofs_apr_oct_summary_statistics",
-                            "chartColor": "white",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "AiQHtl",
-                            "shareKeys": [
-                                "Root Group/Surface Water/Water Observations from Space/April-October water observations"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "November-March water observations",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "wofs_nov_mar_summary_statistics",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "wofs_nov_mar_summary_statistics",
-                            "chartColor": "white",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "hbzXqh",
-                            "shareKeys": [
-                                "Root Group/Surface Water/Water Observations from Space/November-March water observations"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "Annual water observations",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "wofs_annual_summary_statistics",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "wofs_annual_summary_statistics",
-                            "chartColor": "white",
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "SpYxSG",
-                            "shareKeys": [
-                                "Root Group/Surface Water/Water Observations from Space/Annual water observations"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "All water observations",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "wofs_filtered_summary",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "wofs_filtered_summary",
-                            "leafletUpdateInterval": 750,
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "aNt8yM",
-                            "shareKeys": [
-                                "Root Group/Surface Water/Water Observations from Space/All water observations"
-                            ]
-                        },
-                        {
-                            "id": "QnhUWK",
-                            "type": "group",
-                            "name": "April-October water observations source data",
-                            "members": [
-                                {
-                                    "type": "wms",
-                                    "name": "April-October clear observations",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "wofs_apr_oct_summary_clear",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "wofs_apr_oct_summary_clear",
-                                    "chartColor": "white",
-                                    "leafletUpdateInterval": 750,
-                                    "chartType": "momentPoints",
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "M1ThLx",
-                                    "shareKeys": [
-                                        "Root Group/Surface Water/Water Observations from Space/April-October water observations source data/April-October clear observations"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "April-October wet observations",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "wofs_apr_oct_summary_wet",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "wofs_apr_oct_summary_wet",
-                                    "chartColor": "white",
-                                    "leafletUpdateInterval": 750,
-                                    "chartType": "momentPoints",
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "7vSA2T",
-                                    "shareKeys": [
-                                        "Root Group/Surface Water/Water Observations from Space/April-October water observations source data/April-October wet observations"
-                                    ]
-                                }
-                            ],
-                            "shareKeys": [
-                                "Root Group/Surface Water/Water Observations from Space/April-October water observations source data"
-                            ]
-                        },
-                        {
-                            "id": "XNnNVN",
-                            "type": "group",
-                            "name": "November-March water observations source data",
-                            "members": [
-                                {
-                                    "type": "wms",
-                                    "name": "November-March clear observations",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "wofs_nov_mar_summary_clear",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "wofs_nov_mar_summary_clear",
-                                    "chartColor": "white",
-                                    "leafletUpdateInterval": 750,
-                                    "chartType": "momentPoints",
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "HGetFm",
-                                    "shareKeys": [
-                                        "Root Group/Surface Water/Water Observations from Space/November-March water observations source data/November-March clear observations"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "November-March wet observations",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "wofs_nov_mar_summary_wet",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "wofs_nov_mar_summary_wet",
-                                    "chartColor": "white",
-                                    "leafletUpdateInterval": 750,
-                                    "chartType": "momentPoints",
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "iknUf8",
-                                    "shareKeys": [
-                                        "Root Group/Surface Water/Water Observations from Space/November-March water observations source data/November-March wet observations"
-                                    ]
-                                }
-                            ],
-                            "shareKeys": [
-                                "Root Group/Surface Water/Water Observations from Space/November-March water observations source data"
-                            ]
-                        },
-                        {
-                            "id": "AEV4T5",
-                            "type": "group",
-                            "name": "Annual water observations source data",
-                            "members": [
-                                {
-                                    "type": "wms",
-                                    "name": "Annual clear observations",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "wofs_annual_summary_clear",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "wofs_annual_summary_clear",
-                                    "chartColor": "white",
-                                    "leafletUpdateInterval": 750,
-                                    "chartType": "momentPoints",
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "614LVP",
-                                    "shareKeys": [
-                                        "Root Group/Surface Water/Water Observations from Space/Annual water observations source data/Annual clear observations"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "Annual wet observations",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "wofs_annual_summary_wet",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "wofs_annual_summary_wet",
-                                    "chartColor": "white",
-                                    "leafletUpdateInterval": 750,
-                                    "chartType": "momentPoints",
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "1LlNu1",
-                                    "shareKeys": [
-                                        "Root Group/Surface Water/Water Observations from Space/Annual water observations source data/Annual wet observations"
-                                    ]
-                                }
-                            ],
-                            "shareKeys": [
-                                "Root Group/Surface Water/Water Observations from Space/Annual water observations source data"
-                            ]
-                        },
-                        {
-                            "id": "UwUlQP",
-                            "type": "group",
-                            "name": "All water observations combined source data",
-                            "members": [
-                                {
-                                    "type": "wms",
-                                    "name": "All clear observations",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "wofs_summary_clear",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "wofs_summary_clear",
-                                    "leafletUpdateInterval": 750,
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "NhDETf",
-                                    "shareKeys": [
-                                        "Root Group/Surface Water/Water Observations from Space/All water observations combined source data/All clear observations"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "All wet observations",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "wofs_summary_wet",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "wofs_summary_wet",
-                                    "leafletUpdateInterval": 750,
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "Cabw4Q",
-                                    "shareKeys": [
-                                        "Root Group/Surface Water/Water Observations from Space/All water observations combined source data/All wet observations"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "Unfiltered summary of all water observations",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "Water Observations from Space Statistics",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "Water Observations from Space Statistics",
-                                    "leafletUpdateInterval": 750,
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "N7GZZR",
-                                    "shareKeys": [
-                                        "Root Group/Surface Water/Water Observations from Space/All water observations combined source data/Unfiltered summary of all water observations"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "Water observations confidence",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "wofs_filtered_summary_confidence",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "wofs_filtered_summary_confidence",
-                                    "leafletUpdateInterval": 750,
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "7tjxnH",
-                                    "shareKeys": [
-                                        "Root Group/Surface Water/Water Observations from Space/All water observations combined source data/Water observations confidence"
-                                    ]
-                                }
-                            ],
-                            "shareKeys": [
-                                "Root Group/Surface Water/Water Observations from Space/All water observations combined source data"
-                            ]
-                        }
-                    ],
-                    "shareKeys": [
-                        "Root Group/Surface Water/Water Observations from Space"
-                    ]
-                },
-                {
-                    "id": "hNyAH2",
-                    "type": "group",
-                    "name": "DEA Waterbodies",
-                    "members": [
-                        {
-                            "type": "wms",
-                            "name": "DEA Waterbodies",
-                            "url": "https://hotspots.dea.ga.gov.au/geoserver/public/wms",
-                            "chartDisclaimer": "Digital Earth Australia Waterbodies shows the wet surface area of waterbodies as estimated from satellites. It does not show depth, volume, purpose of the waterbody, nor the source of the water. <br> For more detailed information see <a href='https://www.ga.gov.au/dea/products/dea-waterbodies'>https://www.ga.gov.au/dea/products/dea-waterbodies</a>",
-                            "layers": "DigitalEarthAustraliaWaterbodies",
-                            "featureInfoTemplate": {
-                                "template": "<div style='width:600px'><h3>Waterbody Identifier: {{uid}}<br /> Percentage of surface area (not volume) observed as wet</h3><br/><chart id='{{uid}}' title='Waterbody {{uid}}' preview-x-label='Date' sources='{{#terria.urlEncode}}{{timeseries}}{{/terria.urlEncode}}'  column-names='Time,Percentage of total surface area (not volume) observed as wet,Wet Pixel Count' column-units='Date of satellite observation,%,#'></chart>{{>disclaimer}}</div>",
-                                "partials": {
-                                    "disclaimer": "This graph shows the wet surface area of waterbodies as estimated from satellites. It does not show depth, volume, purpose of the waterbody, nor the source of the water. <br> For more detailed information see https://www.ga.gov.au/dea/products/dea-waterbodies."
-                                }
-                            },
-                            "id": "DGGjbr",
-                            "shareKeys": [
-                                "Root Group/Surface Water/Digital Earth Australia Waterbodies/Digital Earth Australia Waterbodies"
-                            ]
-                        }
-                    ],
-                    "shareKeys": [
-                        "Root Group/Surface Water/Digital Earth Australia Waterbodies"
-                    ]
-                },
-                {
-                    "id": "uvJG4R",
-                    "type": "group",
-                    "name": "DEA Wetness Percentiles",
-                    "members": [
-                        {
-                            "type": "wms",
-                            "name": "DEA Wetness Percentiles",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ga_ls_tcw_percentiles_2",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ga_ls_tcw_percentiles_2",
-                            "chartColor": "white",
-                            "chartType": "momentPoints",
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "hbmz55",
-                            "shareKeys": [
-                                "Root Group/Surface Water/DEA Wetness Percentiles (Landsat)/Tasseled Cap Wetness Percentiles"
-                            ]
-                        }
-                    ],
-                    "shareKeys": [
-                        "Root Group/Surface Water/DEA Wetness Percentiles (Landsat)"
-                    ]
-                }
-            ],
-            "shareKeys": ["Root Group/Surface Water", "Root Group/Inland waterbodies", "Root Group/Inland water"]
-        },
-        {
-            "id": "D7zEZL",
-            "type": "group",
-            "name": "Sea, ocean and coast",
-            "members": [
-                {
-                    "id": "dkjsia",
-                    "type": "group",
-                    "name": "DEA Coastlines",
-                    "members": [
-                        {
-                            "type": "wms",
-                            "name": "DEA Coastlines",
-                            "id": "dea_coastlines",
-                            "shortReport": "<i>Zoom in to view detailed rates of coastal change and individual annual coastlines</i></br></br><small>For more information and to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description</a></small>",
-                            "url": "https://geoserver.dea.ga.gov.au/geoserver/wms",
-                            "opacity": 1,
-                            "chartDisclaimer": "The graph below shows the distance (in metres) from each 1988-2018 coastline to the 2019 coastline. Positive distances indicate that a coastline was located towards the ocean from the 2019 coastline; coastlines with negative distances were located further inland.",
-                            "layers": "dea:DEACoastLines",
-                            "featureInfoTemplate": {
-                                "template": "<div style='width:480px'>{{#n}}<h3 style='font-weight:normal'>Digital Earth Australia Coastlines</h3>Zoom in until labelled points appear and click on any point to view a <b>time series chart of how the local coastline has changed over time</b> (press 'Expand' on the pop-up for more detail):</br></br><img src='https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_DEAMaps_1.gif' alt='Clicking on points'></br></br>Zoom in further to view individual annual coastlines:</br></br><img src='https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_DEAMaps_2.gif' alt='Zooming to coastlines'><i></br></br>For more information or to download DEA Coastlines data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description.</a></i></br></br>{{/n}}{{#sce}}<h2 style='font-weight:normal'>This coastline has <b>{{#retreat}}retreated &darr;{{/retreat}}{{#growth}}grown &uarr;{{/growth}}</b> by</br> <b>{{#terria.formatNumber}}{maximumFractionDigits:1}{{rate_time}}{{/terria.formatNumber}} metres (±{{#terria.formatNumber}}{maximumFractionDigits:1}{{conf_time}}{{/terria.formatNumber}}) per year</b></br>on average since <b>1988</b></h2>The coastline at this location was <b>most seaward in {{max_year}}</b>, and <b>most landward in {{min_year}}</b>{{#outl_time}} (excluding outlier years; see below){{/outl_time}}. Since 1988, the median annual position of the coastline has moved over a total distance of approximately <b>{{#terria.formatNumber}}{maximumFractionDigits:0}{{sce}}{{/terria.formatNumber}}  metres.</b></br></br><chart title='DEA Coastlines ({{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.latitude}}{{/terria.formatNumber}}, {{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.longitude}}{{/terria.formatNumber}})' y-column='Distance (metres) relative to 2019 coastline' x-column='Year' column-units='{{terria.timeSeries.units}}' preview-x-label='Year'>Year,Distance (metres) relative to 2019 coastline\n1988,{{dist_1988}}\n1989,{{dist_1989}}\n1990,{{dist_1990}}\n1991,{{dist_1991}}\n1992,{{dist_1992}}\n1993,{{dist_1993}}\n1994,{{dist_1994}}\n1995,{{dist_1995}}\n1996,{{dist_1996}}\n1997,{{dist_1997}}\n1998,{{dist_1998}}\n1999,{{dist_1999}}\n2000,{{dist_2000}}\n2001,{{dist_2001}}\n2002,{{dist_2002}}\n2003,{{dist_2003}}\n2004,{{dist_2004}}\n2005,{{dist_2005}}\n2006,{{dist_2006}}\n2007,{{dist_2007}}\n2008,{{dist_2008}}\n2009,{{dist_2009}}\n2010,{{dist_2010}}\n2011,{{dist_2011}}\n2012,{{dist_2012}}\n2013,{{dist_2013}}\n2014,{{dist_2014}}\n2015,{{dist_2015}}\n2016,{{dist_2016}}\n2017,{{dist_2017}}\n2018,{{dist_2018}}\n2019,{{dist_2019}}</chart>{{#outl_time}}The following years were identified as potential outliers, and should be interpreted with caution:</br></br><b>{{outl_time}}</b></br>{{/outl_time}}</br><b>Note: </b><i>Annual coastline positions shown above represent the median or ‘dominant’ position of the coastline at approximately mean sea level tide (0 m Above Mean Sea Level) for each year. This does not reflect short-term coastal variability, for example changes in shoreline position between low and high tide, seasonal effects, or short-lived influences of individual storms. Annual coastline positions will therefore show lower variability than the true range of short-term coastal variability at this location. </br></br>For more information about the DEA Coastlines coastal change statistics or to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description.</a></i></br></br>{{/sce}}{{#year}}<h2 style='font-weight:normal'>{{year}} annual coastline</h2>This line represents the approximate <b>median</b> (i.e. 'dominant') position of the coastline at <b>0 m Above Mean Sea Level</b> across the entire of {{year}}.</br></br><h3 style='font-weight:normal'>{{#wms_aero}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>aerosol issues</b> caused by the 1991 eruption of Mount Pinatubo.</blockquote>{{/wms_aero}}{{#wms_tidal}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>tidal modelling issues</b>, potentially caused by errors in the tidal model used to constrain coastlines to mean sea level, or the influence of shallow intertidal topography that can lead to inaccurate coastline mapping.</blockquote>{{/wms_tidal}}{{#wms_nodata}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>limited good quality satellite observations</b> in this location. This can reduce the quality of resulting coastline features.</blockquote>{{/wms_nodata}}</h3><b>Note: </b><i>Annual coastlines do not reflect short-term coastal variability, for example changes in shoreline position between low and high tide, seasonal effects, or short-lived influences of individual storms. Annual coastlines will therefore show lower variability than the true range of short-term coastal variability at this location.</br></br>For more information about coastline mapping accuracy and limitations or to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines#details'>DEA Coastlines product description.</a></i></br></br>{{/year}}</div>"
-                            },
-                            "legends": [
-                                {
-                                    "url": "https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_legend 1.png"
-                                }
-                            ],
-                            "shareKeys": [
-                                "Root Group/Coastal/Digital Earth Australia Coastlines/Digital Earth Australia Coastlines (beta)"
-                            ]
-                        },
-                        {
-                            "id": "uHwXvV",
-                            "type": "group",
-                            "name": "Supplementary layers",
-                            "members": [
-                                {
-                                    "type": "wms",
-                                    "name": "Annual coastlines",
-                                    "id": "dea_coastlines_annual",
-                                    "shortReport": "<i>Zoom in to view individual annual coastlines from 1988 to the present</i></br></br><small>For more information and to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description</a></small>",
-                                    "url": "https://geoserver.dea.ga.gov.au/geoserver/wms",
-                                    "opacity": 1,
-                                    "layers": "dea:AnnualCoastlines",
                                     "featureInfoTemplate": {
-                                        "template": "<div style='width:480px'><h2 style='font-weight:normal'>{{year}} annual coastline</h2>This line represents the approximate <b>median</b> (i.e. 'dominant') position of the coastline at <b>0 m Above Mean Sea Level</b> across the entire of {{year}}.</br></br><h3 style='font-weight:normal'>{{#wms_aero}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>aerosol issues</b> caused by the 1991 eruption of Mount Pinatubo.</blockquote>{{/wms_aero}}{{#wms_tidal}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>tidal modelling issues</b>, potentially caused by errors in the tidal model used to constrain coastlines to mean sea level, or the influence of shallow intertidal topography that can lead to inaccurate coastline mapping.</blockquote>{{/wms_tidal}}{{#wms_nodata}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>limited good quality satellite observations</b> in this location. This can reduce the quality of resulting coastline features.</blockquote>{{/wms_nodata}}</h3><b>Note: </b><i>Annual coastlines do not reflect short-term coastal variability, for example changes in shoreline position between low and high tide, seasonal effects, or short-lived influences of individual storms. Annual coastlines will therefore show lower variability than the true range of short-term coastal variability at this location.</br></br>For more information about coastline mapping accuracy and limitations or to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines#details'>DEA Coastlines product description.</a></i></br></br></div>"
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{data.0.bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{data.0.bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{data.0.bands.blue}}\n560,{{data.0.bands.green}}\n660,{{data.0.bands.red}}\n870,{{data.0.bands.nir}}\n1610,{{data.0.bands.swir1}}\n2200,{{data.0.bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
                                     },
-                                    "legends": [
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "dateFormat": "'Year: 'yyyy",
+                                    "id": "hAUsXi",
+                                    "shareKeys": [
+                                        "Root Group/Satellite images/Satellite images 25m - annual/Yearly average Landsat 8 satellite images"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance Calendar Year (Landsat 7 ETM+)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ls7_nbart_geomedian_annual",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ls7_nbart_geomedian_annual",
+                                    "chartColor": "white",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.blue}}\n560,{{data.0.bands.green}}\n660,{{data.0.bands.red}}\n840,{{data.0.bands.nir}}\n1650,{{data.0.bands.swir1}}\n2220,{{data.0.bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "dateFormat": "'Year: 'yyyy",
+                                    "id": "pwDY6b",
+                                    "shareKeys": [
+                                        "Root Group/Satellite images/Satellite images 25m - annual/Yearly average Landsat 7 satellite images"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance Calendar Year (Landsat 5 TM)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ls5_nbart_geomedian_annual",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ls5_nbart_geomedian_annual",
+                                    "chartColor": "white",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.blue}}\n560,{{data.0.bands.green}}\n660,{{data.0.bands.red}}\n840,{{data.0.bands.nir}}\n1650,{{data.0.bands.swir1}}\n2220,{{data.0.bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "dateFormat": "'Year: 'yyyy",
+                                    "id": "BpKM2u",
+                                    "shareKeys": [
+                                        "Root Group/Satellite images/Satellite images 25m - annual/Yearly average Landsat 5 satellite images"
+                                    ]
+                                }
+                            ],
+                            "shareKeys": [
+                                "Root Group/Satellite images/Satellite images 25m - annual"
+                            ]
+                        },
+                        {
+                            "id": "aN8xKz",
+                            "type": "group",
+                            "name": "DEA Surface Reflectance (Landsat)",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Landsat 8 OLI-TIRS)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ga_ls8c_ard_3",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ga_ls8c_ard_3",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n870,{{data.0.bands.nbart_nir}}\n1610,{{data.0.bands.nbart_swir_1}}\n2200,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "5k8KR4",
+                                    "shareKeys": [
+                                        "Root Group/Satellite images/Satellite images 25m - daily/Daily Landsat 8 satellite images"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Landst 7 ETM+)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ga_ls7e_ard_3",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ga_ls7e_ard_3",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n840,{{data.0.bands.nbart_nir}}\n1650,{{data.0.bands.nbart_swir_1}}\n2220,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "bzDSiT",
+                                    "shareKeys": [
+                                        "Root Group/Satellite images/Satellite images 25m - daily/Daily Landsat 7 satellite images"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Landsat 5 TM)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ga_ls5t_ard_3",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ga_ls5t_ard_3",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n840,{{data.0.bands.nbart_nir}}\n1650,{{data.0.bands.nbart_swir_1}}\n2220,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "rESkby",
+                                    "shareKeys": [
+                                        "Root Group/Satellite images/Satellite images 25m - daily/Daily Landsat 5 satellite images"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Landsat, Provisional)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ga_ls_ard_provisional_3",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ga_ls_ard_provisional_3",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Normalised Difference Vegetation Index</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>Normalised Difference Water Index</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>Modified Normalised Difference Water Index</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>Normalised Burn Ratio</b></td><td>{{data.0.band_derived.nbr}}</td></tr></table><p><chart id='{{x}}{{y}}{{time}}' title='NBART at {{x}},{{y}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n840,{{data.0.bands.nbart_nir}}\n1650,{{data.0.bands.nbart_swir1}}\n2220,{{data.0.bands.nbart_swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "98SDFs"
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Landsat 8 OLI-TIRS, Provisional)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ga_ls8c_ard_provisional_3",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ga_ls8c_ard_provisional_3",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n870,{{data.0.bands.nbart_nir}}\n1610,{{data.0.bands.nbart_swir_1}}\n2200,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "dfsRY4"
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Landst 7 ETM+, Provisional)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ga_ls7e_ard_provisional_3",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ga_ls7e_ard_provisional_3",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n840,{{data.0.bands.nbart_nir}}\n1650,{{data.0.bands.nbart_swir_1}}\n2220,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "456FGw"
+                                }
+                            ],
+                            "shareKeys": [
+                                "Root Group/Satellite images/Satellite images 25m - daily"
+                            ]
+                        },
+                        {
+                            "id": "x7b8dq",
+                            "type": "group",
+                            "name": "DEA Surface Reflectance (Sentinel-2)",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Sentinel-2A MSI Near Real Time)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "s2a_nrt_granule_nbar_t",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "s2a_nrt_granule_nbar_t",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{data.0.bands.nbart_coastal_aerosol}}\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n670,{{data.0.bands.nbart_red}}\n710,{{data.0.bands.nbart_red_edge_1}}\n740,{{data.0.bands.nbart_red_edge_2}}\n780,{{data.0.bands.nbart_red_edge_3}}\n840,{{data.0.bands.nbart_nir_1}}\n870,{{data.0.bands.nbart_nir_2}}\n1610,{{data.0.bands.nbart_swir_2}}\n2190,{{data.0.bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "8apTli",
+                                    "shareKeys": [
+                                        "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 90-day expedited satellite images/Expedited Sentinel 2A satellite images"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Sentinel-2B MSI Near Real Time)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "s2b_nrt_granule_nbar_t",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "s2b_nrt_granule_nbar_t",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{data.0.bands.nbart_coastal_aerosol}}\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n670,{{data.0.bands.nbart_red}}\n710,{{data.0.bands.nbart_red_edge_1}}\n740,{{data.0.bands.nbart_red_edge_2}}\n780,{{data.0.bands.nbart_red_edge_3}}\n840,{{data.0.bands.nbart_nir_1}}\n870,{{data.0.bands.nbart_nir_2}}\n1610,{{data.0.bands.nbart_swir_2}}\n2190,{{data.0.bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "AuD7kv",
+                                    "shareKeys": [
+                                        "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 90-day expedited satellite images/Expedited Sentinel 2B satellite images"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Sentinel-2A MSI)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "s2a_ard_granule_nbar_t",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "s2a_ard_granule_nbar_t",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbar_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbar_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbar_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbar_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbar_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbar_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbar_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbar_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbar_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbar_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbar_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBAR at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBAR Reflectance'>nm,NBAR Reflectance\n440,{{data.0.bands.nbar_coastal_aerosol}}\n490,{{data.0.bands.nbar_blue}}\n560,{{data.0.bands.nbar_green}}\n670,{{data.0.bands.nbar_red}}\n710,{{data.0.bands.nbar_red_edge_1}}\n740,{{data.0.bands.nbar_red_edge_2}}\n780,{{data.0.bands.nbar_red_edge_3}}\n840,{{data.0.bands.nbar_nir_1}}\n870,{{data.0.bands.nbar_nir_2}}\n1610,{{data.0.bands.nbar_swir_2}}\n2190,{{data.0.bands.nbar_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "iNJKMD",
+                                    "shareKeys": [
+                                        "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 satellite imagery archive/Sentinel 2a satellite images"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Sentinel-2B MSI)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "s2b_ard_granule_nbar_t",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "s2b_ard_granule_nbar_t",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbar_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbar_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbar_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbar_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbar_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbar_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbar_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbar_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbar_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbar_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbar_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBAR at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBAR Reflectance'>nm,NBAR Reflectance\n440,{{data.0.bands.nbar_coastal_aerosol}}\n490,{{data.0.bands.nbar_blue}}\n560,{{data.0.bands.nbar_green}}\n670,{{data.0.bands.nbar_red}}\n710,{{data.0.bands.nbar_red_edge_1}}\n740,{{data.0.bands.nbar_red_edge_2}}\n780,{{data.0.bands.nbar_red_edge_3}}\n840,{{data.0.bands.nbar_nir_1}}\n870,{{data.0.bands.nbar_nir_2}}\n1610,{{data.0.bands.nbar_swir_2}}\n2190,{{data.0.bands.nbar_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "RACNHJ",
+                                    "shareKeys": [
+                                        "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 satellite imagery archive/Sentinel 2b satellite images"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Sentinel-2, Provisional)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "s2_nrt_provisional_granule_nbar_t",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "s2_nrt_provisional_granule_nbar_t",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{data.0.bands.nbart_coastal_aerosol}}\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n670,{{data.0.bands.nbart_red}}\n710,{{data.0.bands.nbart_red_edge_1}}\n740,{{data.0.bands.nbart_red_edge_2}}\n780,{{data.0.bands.nbart_red_edge_3}}\n840,{{data.0.bands.nbart_nir_1}}\n870,{{data.0.bands.nbart_nir_2}}\n1610,{{data.0.bands.nbart_swir_2}}\n2190,{{data.0.bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "IUTY45"
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Sentinel-2A MSI, Provisional)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "s2a_nrt_provisional_granule_nbar_t",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "s2a_nrt_provisional_granule_nbar_t",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{data.0.bands.nbart_coastal_aerosol}}\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n670,{{data.0.bands.nbart_red}}\n710,{{data.0.bands.nbart_red_edge_1}}\n740,{{data.0.bands.nbart_red_edge_2}}\n780,{{data.0.bands.nbart_red_edge_3}}\n840,{{data.0.bands.nbart_nir_1}}\n870,{{data.0.bands.nbart_nir_2}}\n1610,{{data.0.bands.nbart_swir_2}}\n2190,{{data.0.bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "SDF32t"
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Sentinel-2B MSI, Provisional)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "s2b_nrt_provisional_granule_nbar_t",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "s2b_nrt_provisional_granule_nbar_t",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{data.0.bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{data.0.bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{data.0.bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{data.0.bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{data.0.bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{data.0.bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, NIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>NDCI - Red Edge, Red</b></td><td>{{data.0.band_derived.ndci}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{data.0.time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{data.0.bands.nbart_coastal_aerosol}}\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n670,{{data.0.bands.nbart_red}}\n710,{{data.0.bands.nbart_red_edge_1}}\n740,{{data.0.bands.nbart_red_edge_2}}\n780,{{data.0.bands.nbart_red_edge_3}}\n840,{{data.0.bands.nbart_nir_1}}\n870,{{data.0.bands.nbart_nir_2}}\n1610,{{data.0.bands.nbart_swir_2}}\n2190,{{data.0.bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "fgh369"
+                                }
+                            ],
+                            "shareKeys": [
+                                "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 satellite imagery archive"
+                            ]
+                        }
+                    ],
+                    "shareKeys": ["Root Group/Satellite images", "Root Group/Satellite data", "Root Group/Baseline satellite data"]
+                },
+                {
+                    "id": "ahjVXr",
+                    "type": "group",
+                    "name": "Land and vegetation",
+                    "members": [
+                        {
+                            "id": "irRsX3",
+                            "type": "group",
+                            "name": "DEA Fractional Cover",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Fractional Cover (Landsat)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ga_ls_fc_3",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ga_ls_fc_3",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "mYnkqY",
+                                    "shareKeys": [
+                                        "Root Group/Vegetation/Fractional Cover/Daily Fractional Cover observations"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "Seasonal Fractional Cover",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "fcp_seasonal_rgb",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "fcp_seasonal_rgb",
+                                    "chartColor": "white",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "8uKmJ8",
+                                    "shareKeys": [
+                                        "Root Group/Vegetation/Fractional Cover/Seasonal Fractional Cover"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "Annual Fractional Cover",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "fcp_rgb",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "fcp_rgb",
+                                    "chartColor": "white",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "dateFormat": "'Year: 'yyyy",
+                                    "id": "BLxe8I",
+                                    "shareKeys": [
+                                        "Root Group/Vegetation/Fractional Cover/Annual Fractional Cover"
+                                    ]
+                                },
+                                {
+                                    "id": "rTKE41",
+                                    "type": "group",
+                                    "name": "Seasonal Fractional Cover summaries",
+                                    "members": [
                                         {
-                                            "url": "https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_legend 1.png"
+                                            "type": "wms",
+                                            "name": "Seasonal Green Vegetation",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "fcp_seasonal_green_veg",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "fcp_seasonal_green_veg",
+                                            "chartColor": "white",
+                                            "leafletUpdateInterval": 750,
+                                            "chartType": "momentPoints",
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "id": "BL3iXJ",
+                                            "shareKeys": [
+                                                "Root Group/Vegetation/Fractional Cover/Seasonal Fractional Cover summaries/Seasonal Green Vegetation"
+                                            ]
+                                        },
+                                        {
+                                            "type": "wms",
+                                            "name": "Seasonal Non-Green Vegetation",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "fcp_seasonal_non_green_veg",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "fcp_seasonal_non_green_veg",
+                                            "chartColor": "white",
+                                            "leafletUpdateInterval": 750,
+                                            "chartType": "momentPoints",
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "id": "uqGrkN",
+                                            "shareKeys": [
+                                                "Root Group/Vegetation/Fractional Cover/Seasonal Fractional Cover summaries/Seasonal Non-Green Vegetation"
+                                            ]
+                                        },
+                                        {
+                                            "type": "wms",
+                                            "name": "Seasonal Bare Ground",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "fcp_seasonal_bare_ground",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "fcp_seasonal_bare_ground",
+                                            "chartColor": "white",
+                                            "leafletUpdateInterval": 750,
+                                            "chartType": "momentPoints",
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "id": "VScBTN",
+                                            "shareKeys": [
+                                                "Root Group/Vegetation/Fractional Cover/Seasonal Fractional Cover summaries/Seasonal Bare Ground"
+                                            ]
                                         }
                                     ],
                                     "shareKeys": [
-                                        "Root Group/Coastal/Digital Earth Australia Coastlines/Supplementary layers/Annual coastlines"
+                                        "Root Group/Vegetation/Fractional Cover/Seasonal Fractional Cover summaries"
+                                    ]
+                                },
+                                {
+                                    "id": "nI2Kfn",
+                                    "type": "group",
+                                    "name": "Annual Fractional Cover summaries",
+                                    "members": [
+                                        {
+                                            "type": "wms",
+                                            "name": "Annual Green Vegetation",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "fcp_green_veg",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "fcp_green_veg",
+                                            "chartColor": "white",
+                                            "leafletUpdateInterval": 750,
+                                            "chartType": "momentPoints",
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "dateFormat": "'Year: 'yyyy",
+                                            "id": "7eJRQy",
+                                            "shareKeys": [
+                                                "Root Group/Vegetation/Fractional Cover/Annual Fractional Cover summaries/Annual Green Vegetation"
+                                            ]
+                                        },
+                                        {
+                                            "type": "wms",
+                                            "name": "Annual Non-Green Vegetation",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "fcp_non_green_veg",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "fcp_non_green_veg",
+                                            "chartColor": "white",
+                                            "leafletUpdateInterval": 750,
+                                            "chartType": "momentPoints",
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "dateFormat": "'Year: 'yyyy",
+                                            "id": "uFlnzu",
+                                            "shareKeys": [
+                                                "Root Group/Vegetation/Fractional Cover/Annual Fractional Cover summaries/Annual Non-Green Vegetation"
+                                            ]
+                                        },
+                                        {
+                                            "type": "wms",
+                                            "name": "Annual Bare Ground",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "fcp_bare_ground",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "fcp_bare_ground",
+                                            "chartColor": "white",
+                                            "leafletUpdateInterval": 750,
+                                            "chartType": "momentPoints",
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "dateFormat": "'Year: 'yyyy",
+                                            "id": "L1wwAP",
+                                            "shareKeys": [
+                                                "Root Group/Vegetation/Fractional Cover/Annual Fractional Cover summaries/Annual Bare Ground"
+                                            ]
+                                        }
+                                    ],
+                                    "shareKeys": [
+                                        "Root Group/Vegetation/Fractional Cover/Annual Fractional Cover summaries"
+                                    ]
+                                }
+                            ],
+                            "shareKeys": ["Root Group/Vegetation/Fractional Cover"]
+                        },
+                        {
+                            "id": "462q3S",
+                            "type": "group",
+                            "name": "DEA Mangroves",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Mangroves (Landsat)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "mangrove_cover_v2_0_2",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "mangrove_cover_v2_0_2",
+                                    "chartColor": "white",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "dateFormat": "'Year: 'yyyy",
+                                    "id": "3gjEXB",
+                                    "shareKeys": [
+                                        "Root Group/Vegetation/Mangrove Canopy Cover"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "u8GXYD",
+                            "type": "group",
+                            "name": "GA Barest Earth",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "GA Barest Earth (Landsat 8 OLI/TIRS)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ls8_barest_earth_mosaic",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ls8_barest_earth_mosaic",
+                                    "chartColor": "white",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{data.0.bands.nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.swir1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{data.0.bands.swir2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{data.0.bands.blue}}\n560,{{data.0.bands.green}}\n660,{{data.0.bands.red}}\n870,{{data.0.bands.nir}}\n1610,{{data.0.bands.swir1}}\n2200,{{data.0.bands.swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "Mn56Pg",
+                                    "shareKeys": [
+                                        "Root Group/Satellite images/Satellite images 25m - Barest Earth/Barest Earth Landsat 8 satellite images"
                                     ]
                                 },
                                 {
                                     "type": "wms",
-                                    "name": "Rates of change statistics",
-                                    "id": "dea_coastlines_statistics",
-                                    "shortReport": "<i>Zoom in to view detailed rates of coastal change along the Australian coastline</i></br></br><small>For more information and to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description</a></small>",
+                                    "name": "GA Barest Earth (Landsat)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "landsat_barest_earth",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "landsat_barest_earth",
+                                    "chartColor": "white",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "WRTIQP",
+                                    "shareKeys": [
+                                        "Root Group/Satellite images/Satellite images 25m - Barest Earth/Landsat 30+ Barest Earth Satellite Images (Combined Landsat)"
+                                    ]
+                                }
+                            ],
+                            "shareKeys": [
+                                "Root Group/Satellite images/Satellite images 25m - Barest Earth"
+                            ]
+                        }
+                    ],
+                    "shareKeys": ["Root Group/Vegetation"]
+                },
+                {
+                    "id": "dn823X",
+                    "type": "group",
+                    "name": "Inland water",
+                    "members": [
+                        {
+                            "id": "3iIq5b",
+                            "type": "group",
+                            "name": "DEA Water Observations (WOfS)",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Water Observations (Landsat)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ga_ls_wo_3",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ga_ls_wo_3",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "iun7iP",
+                                    "shareKeys": [
+                                        "Root Group/Surface Water/Water Observations from Space/Daily water observations"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "April-October water observations",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "wofs_apr_oct_summary_statistics",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "wofs_apr_oct_summary_statistics",
+                                    "chartColor": "white",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "AiQHtl",
+                                    "shareKeys": [
+                                        "Root Group/Surface Water/Water Observations from Space/April-October water observations"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "November-March water observations",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "wofs_nov_mar_summary_statistics",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "wofs_nov_mar_summary_statistics",
+                                    "chartColor": "white",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "dateFormat": "'Year: 'yyyy",
+                                    "id": "hbzXqh",
+                                    "shareKeys": [
+                                        "Root Group/Surface Water/Water Observations from Space/November-March water observations"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "Annual water observations",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "wofs_annual_summary_statistics",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "wofs_annual_summary_statistics",
+                                    "chartColor": "white",
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "dateFormat": "'Year: 'yyyy",
+                                    "id": "SpYxSG",
+                                    "shareKeys": [
+                                        "Root Group/Surface Water/Water Observations from Space/Annual water observations"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "All water observations",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "wofs_filtered_summary",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "wofs_filtered_summary",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "aNt8yM",
+                                    "shareKeys": [
+                                        "Root Group/Surface Water/Water Observations from Space/All water observations"
+                                    ]
+                                },
+                                {
+                                    "id": "QnhUWK",
+                                    "type": "group",
+                                    "name": "April-October water observations source data",
+                                    "members": [
+                                        {
+                                            "type": "wms",
+                                            "name": "April-October clear observations",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "wofs_apr_oct_summary_clear",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "wofs_apr_oct_summary_clear",
+                                            "chartColor": "white",
+                                            "leafletUpdateInterval": 750,
+                                            "chartType": "momentPoints",
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "dateFormat": "'Year: 'yyyy",
+                                            "id": "M1ThLx",
+                                            "shareKeys": [
+                                                "Root Group/Surface Water/Water Observations from Space/April-October water observations source data/April-October clear observations"
+                                            ]
+                                        },
+                                        {
+                                            "type": "wms",
+                                            "name": "April-October wet observations",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "wofs_apr_oct_summary_wet",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "wofs_apr_oct_summary_wet",
+                                            "chartColor": "white",
+                                            "leafletUpdateInterval": 750,
+                                            "chartType": "momentPoints",
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "dateFormat": "'Year: 'yyyy",
+                                            "id": "7vSA2T",
+                                            "shareKeys": [
+                                                "Root Group/Surface Water/Water Observations from Space/April-October water observations source data/April-October wet observations"
+                                            ]
+                                        }
+                                    ],
+                                    "shareKeys": [
+                                        "Root Group/Surface Water/Water Observations from Space/April-October water observations source data"
+                                    ]
+                                },
+                                {
+                                    "id": "XNnNVN",
+                                    "type": "group",
+                                    "name": "November-March water observations source data",
+                                    "members": [
+                                        {
+                                            "type": "wms",
+                                            "name": "November-March clear observations",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "wofs_nov_mar_summary_clear",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "wofs_nov_mar_summary_clear",
+                                            "chartColor": "white",
+                                            "leafletUpdateInterval": 750,
+                                            "chartType": "momentPoints",
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "dateFormat": "'Year: 'yyyy",
+                                            "id": "HGetFm",
+                                            "shareKeys": [
+                                                "Root Group/Surface Water/Water Observations from Space/November-March water observations source data/November-March clear observations"
+                                            ]
+                                        },
+                                        {
+                                            "type": "wms",
+                                            "name": "November-March wet observations",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "wofs_nov_mar_summary_wet",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "wofs_nov_mar_summary_wet",
+                                            "chartColor": "white",
+                                            "leafletUpdateInterval": 750,
+                                            "chartType": "momentPoints",
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "dateFormat": "'Year: 'yyyy",
+                                            "id": "iknUf8",
+                                            "shareKeys": [
+                                                "Root Group/Surface Water/Water Observations from Space/November-March water observations source data/November-March wet observations"
+                                            ]
+                                        }
+                                    ],
+                                    "shareKeys": [
+                                        "Root Group/Surface Water/Water Observations from Space/November-March water observations source data"
+                                    ]
+                                },
+                                {
+                                    "id": "AEV4T5",
+                                    "type": "group",
+                                    "name": "Annual water observations source data",
+                                    "members": [
+                                        {
+                                            "type": "wms",
+                                            "name": "Annual clear observations",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "wofs_annual_summary_clear",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "wofs_annual_summary_clear",
+                                            "chartColor": "white",
+                                            "leafletUpdateInterval": 750,
+                                            "chartType": "momentPoints",
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "dateFormat": "'Year: 'yyyy",
+                                            "id": "614LVP",
+                                            "shareKeys": [
+                                                "Root Group/Surface Water/Water Observations from Space/Annual water observations source data/Annual clear observations"
+                                            ]
+                                        },
+                                        {
+                                            "type": "wms",
+                                            "name": "Annual wet observations",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "wofs_annual_summary_wet",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "wofs_annual_summary_wet",
+                                            "chartColor": "white",
+                                            "leafletUpdateInterval": 750,
+                                            "chartType": "momentPoints",
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "dateFormat": "'Year: 'yyyy",
+                                            "id": "1LlNu1",
+                                            "shareKeys": [
+                                                "Root Group/Surface Water/Water Observations from Space/Annual water observations source data/Annual wet observations"
+                                            ]
+                                        }
+                                    ],
+                                    "shareKeys": [
+                                        "Root Group/Surface Water/Water Observations from Space/Annual water observations source data"
+                                    ]
+                                },
+                                {
+                                    "id": "UwUlQP",
+                                    "type": "group",
+                                    "name": "All water observations combined source data",
+                                    "members": [
+                                        {
+                                            "type": "wms",
+                                            "name": "All clear observations",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "wofs_summary_clear",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "wofs_summary_clear",
+                                            "leafletUpdateInterval": 750,
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "id": "NhDETf",
+                                            "shareKeys": [
+                                                "Root Group/Surface Water/Water Observations from Space/All water observations combined source data/All clear observations"
+                                            ]
+                                        },
+                                        {
+                                            "type": "wms",
+                                            "name": "All wet observations",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "wofs_summary_wet",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "wofs_summary_wet",
+                                            "leafletUpdateInterval": 750,
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "id": "Cabw4Q",
+                                            "shareKeys": [
+                                                "Root Group/Surface Water/Water Observations from Space/All water observations combined source data/All wet observations"
+                                            ]
+                                        },
+                                        {
+                                            "type": "wms",
+                                            "name": "Unfiltered summary of all water observations",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "Water Observations from Space Statistics",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "Water Observations from Space Statistics",
+                                            "leafletUpdateInterval": 750,
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "id": "N7GZZR",
+                                            "shareKeys": [
+                                                "Root Group/Surface Water/Water Observations from Space/All water observations combined source data/Unfiltered summary of all water observations"
+                                            ]
+                                        },
+                                        {
+                                            "type": "wms",
+                                            "name": "Water observations confidence",
+                                            "url": "https://ows.dea.ga.gov.au/",
+                                            "opacity": 1,
+                                            "layers": "wofs_filtered_summary_confidence",
+                                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                            "linkedWcsCoverage": "wofs_filtered_summary_confidence",
+                                            "leafletUpdateInterval": 750,
+                                            "tileErrorHandlingOptions": {
+                                                "ignoreUnknownTileErrors": true
+                                            },
+                                            "id": "7tjxnH",
+                                            "shareKeys": [
+                                                "Root Group/Surface Water/Water Observations from Space/All water observations combined source data/Water observations confidence"
+                                            ]
+                                        }
+                                    ],
+                                    "shareKeys": [
+                                        "Root Group/Surface Water/Water Observations from Space/All water observations combined source data"
+                                    ]
+                                }
+                            ],
+                            "shareKeys": [
+                                "Root Group/Surface Water/Water Observations from Space"
+                            ]
+                        },
+                        {
+                            "id": "hNyAH2",
+                            "type": "group",
+                            "name": "DEA Waterbodies",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Waterbodies",
+                                    "url": "https://hotspots.dea.ga.gov.au/geoserver/public/wms",
+                                    "chartDisclaimer": "Digital Earth Australia Waterbodies shows the wet surface area of waterbodies as estimated from satellites. It does not show depth, volume, purpose of the waterbody, nor the source of the water. <br> For more detailed information see <a href='https://www.ga.gov.au/dea/products/dea-waterbodies'>https://www.ga.gov.au/dea/products/dea-waterbodies</a>",
+                                    "layers": "DigitalEarthAustraliaWaterbodies",
+                                    "featureInfoTemplate": {
+                                        "template": "<div style='width:600px'><h3>Waterbody Identifier: {{uid}}<br /> Percentage of surface area (not volume) observed as wet</h3><br/><chart id='{{uid}}' title='Waterbody {{uid}}' preview-x-label='Date' sources='{{#terria.urlEncode}}{{timeseries}}{{/terria.urlEncode}}'  column-names='Time,Percentage of total surface area (not volume) observed as wet,Wet Pixel Count' column-units='Date of satellite observation,%,#'></chart>{{>disclaimer}}</div>",
+                                        "partials": {
+                                            "disclaimer": "This graph shows the wet surface area of waterbodies as estimated from satellites. It does not show depth, volume, purpose of the waterbody, nor the source of the water. <br> For more detailed information see https://www.ga.gov.au/dea/products/dea-waterbodies."
+                                        }
+                                    },
+                                    "id": "DGGjbr",
+                                    "shareKeys": [
+                                        "Root Group/Surface Water/Digital Earth Australia Waterbodies/Digital Earth Australia Waterbodies"
+                                    ]
+                                }
+                            ],
+                            "shareKeys": [
+                                "Root Group/Surface Water/Digital Earth Australia Waterbodies"
+                            ]
+                        },
+                        {
+                            "id": "uvJG4R",
+                            "type": "group",
+                            "name": "DEA Wetness Percentiles",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Wetness Percentiles",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ga_ls_tcw_percentiles_2",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ga_ls_tcw_percentiles_2",
+                                    "chartColor": "white",
+                                    "chartType": "momentPoints",
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "hbmz55",
+                                    "shareKeys": [
+                                        "Root Group/Surface Water/DEA Wetness Percentiles (Landsat)/Tasseled Cap Wetness Percentiles"
+                                    ]
+                                }
+                            ],
+                            "shareKeys": [
+                                "Root Group/Surface Water/DEA Wetness Percentiles (Landsat)"
+                            ]
+                        }
+                    ],
+                    "shareKeys": ["Root Group/Surface Water", "Root Group/Inland waterbodies", "Root Group/Inland water"]
+                },
+                {
+                    "id": "D7zEZL",
+                    "type": "group",
+                    "name": "Sea, ocean and coast",
+                    "members": [
+                        {
+                            "id": "dkjsia",
+                            "type": "group",
+                            "name": "DEA Coastlines",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Coastlines",
+                                    "id": "dea_coastlines",
+                                    "shortReport": "<i>Zoom in to view detailed rates of coastal change and individual annual coastlines</i></br></br><small>For more information and to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description</a></small>",
                                     "url": "https://geoserver.dea.ga.gov.au/geoserver/wms",
                                     "opacity": 1,
                                     "chartDisclaimer": "The graph below shows the distance (in metres) from each 1988-2018 coastline to the 2019 coastline. Positive distances indicate that a coastline was located towards the ocean from the 2019 coastline; coastlines with negative distances were located further inland.",
-                                    "layers": "dea:RateOfChangeStatistics",
+                                    "layers": "dea:DEACoastLines",
                                     "featureInfoTemplate": {
-                                        "template": "<div style='width:480px'><h2 style='font-weight:normal'>This coastline has <b>{{#retreat}}retreated &darr;{{/retreat}}{{#growth}}grown &uarr;{{/growth}}</b> by</br> <b>{{#terria.formatNumber}}{maximumFractionDigits:1}{{rate_time}}{{/terria.formatNumber}} metres (±{{#terria.formatNumber}}{maximumFractionDigits:1}{{conf_time}}{{/terria.formatNumber}}) per year</b></br>on average since <b>1988</b></h2>The coastline at this location was <b>most seaward in {{max_year}}</b>, and <b>most landward in {{min_year}}</b>{{#outl_time}} (excluding outlier years; see below){{/outl_time}}. Since 1988, the median annual position of the coastline has moved over a total distance of approximately <b>{{#terria.formatNumber}}{maximumFractionDigits:0}{{sce}}{{/terria.formatNumber}}  metres.</b></br></br><chart title='DEA Coastlines ({{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.latitude}}{{/terria.formatNumber}}, {{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.longitude}}{{/terria.formatNumber}})' y-column='Distance (metres) relative to 2019 coastline' x-column='Year' column-units='{{terria.timeSeries.units}}' preview-x-label='Year'>Year,Distance (metres) relative to 2019 coastline\n1988,{{dist_1988}}\n1989,{{dist_1989}}\n1990,{{dist_1990}}\n1991,{{dist_1991}}\n1992,{{dist_1992}}\n1993,{{dist_1993}}\n1994,{{dist_1994}}\n1995,{{dist_1995}}\n1996,{{dist_1996}}\n1997,{{dist_1997}}\n1998,{{dist_1998}}\n1999,{{dist_1999}}\n2000,{{dist_2000}}\n2001,{{dist_2001}}\n2002,{{dist_2002}}\n2003,{{dist_2003}}\n2004,{{dist_2004}}\n2005,{{dist_2005}}\n2006,{{dist_2006}}\n2007,{{dist_2007}}\n2008,{{dist_2008}}\n2009,{{dist_2009}}\n2010,{{dist_2010}}\n2011,{{dist_2011}}\n2012,{{dist_2012}}\n2013,{{dist_2013}}\n2014,{{dist_2014}}\n2015,{{dist_2015}}\n2016,{{dist_2016}}\n2017,{{dist_2017}}\n2018,{{dist_2018}}\n2019,{{dist_2019}}</chart>{{#outl_time}}The following years were identified as potential outliers, and should be interpreted with caution:</br></br><b>{{outl_time}}</b></br>{{/outl_time}}</br><b>Note: </b><i>Annual coastline positions shown above represent the median or ‘dominant’ position of the coastline at approximately mean sea level tide (0 m Above Mean Sea Level) for each year. This does not reflect short-term coastal variability, for example changes in shoreline position between low and high tide, seasonal effects, or short-lived influences of individual storms. Annual coastline positions will therefore show lower variability than the true range of short-term coastal variability at this location. </br></br>For more information about the DEA Coastlines coastal change statistics or to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description.</a></i></br></br></div>"
+                                        "template": "<div style='width:480px'>{{#n}}<h3 style='font-weight:normal'>Digital Earth Australia Coastlines</h3>Zoom in until labelled points appear and click on any point to view a <b>time series chart of how the local coastline has changed over time</b> (press 'Expand' on the pop-up for more detail):</br></br><img src='https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_DEAMaps_1.gif' alt='Clicking on points'></br></br>Zoom in further to view individual annual coastlines:</br></br><img src='https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_DEAMaps_2.gif' alt='Zooming to coastlines'><i></br></br>For more information or to download DEA Coastlines data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description.</a></i></br></br>{{/n}}{{#sce}}<h2 style='font-weight:normal'>This coastline has <b>{{#retreat}}retreated &darr;{{/retreat}}{{#growth}}grown &uarr;{{/growth}}</b> by</br> <b>{{#terria.formatNumber}}{maximumFractionDigits:1}{{rate_time}}{{/terria.formatNumber}} metres (±{{#terria.formatNumber}}{maximumFractionDigits:1}{{conf_time}}{{/terria.formatNumber}}) per year</b></br>on average since <b>1988</b></h2>The coastline at this location was <b>most seaward in {{max_year}}</b>, and <b>most landward in {{min_year}}</b>{{#outl_time}} (excluding outlier years; see below){{/outl_time}}. Since 1988, the median annual position of the coastline has moved over a total distance of approximately <b>{{#terria.formatNumber}}{maximumFractionDigits:0}{{sce}}{{/terria.formatNumber}}  metres.</b></br></br><chart title='DEA Coastlines ({{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.latitude}}{{/terria.formatNumber}}, {{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.longitude}}{{/terria.formatNumber}})' y-column='Distance (metres) relative to 2019 coastline' x-column='Year' column-units='{{terria.timeSeries.units}}' preview-x-label='Year'>Year,Distance (metres) relative to 2019 coastline\n1988,{{dist_1988}}\n1989,{{dist_1989}}\n1990,{{dist_1990}}\n1991,{{dist_1991}}\n1992,{{dist_1992}}\n1993,{{dist_1993}}\n1994,{{dist_1994}}\n1995,{{dist_1995}}\n1996,{{dist_1996}}\n1997,{{dist_1997}}\n1998,{{dist_1998}}\n1999,{{dist_1999}}\n2000,{{dist_2000}}\n2001,{{dist_2001}}\n2002,{{dist_2002}}\n2003,{{dist_2003}}\n2004,{{dist_2004}}\n2005,{{dist_2005}}\n2006,{{dist_2006}}\n2007,{{dist_2007}}\n2008,{{dist_2008}}\n2009,{{dist_2009}}\n2010,{{dist_2010}}\n2011,{{dist_2011}}\n2012,{{dist_2012}}\n2013,{{dist_2013}}\n2014,{{dist_2014}}\n2015,{{dist_2015}}\n2016,{{dist_2016}}\n2017,{{dist_2017}}\n2018,{{dist_2018}}\n2019,{{dist_2019}}</chart>{{#outl_time}}The following years were identified as potential outliers, and should be interpreted with caution:</br></br><b>{{outl_time}}</b></br>{{/outl_time}}</br><b>Note: </b><i>Annual coastline positions shown above represent the median or ‘dominant’ position of the coastline at approximately mean sea level tide (0 m Above Mean Sea Level) for each year. This does not reflect short-term coastal variability, for example changes in shoreline position between low and high tide, seasonal effects, or short-lived influences of individual storms. Annual coastline positions will therefore show lower variability than the true range of short-term coastal variability at this location. </br></br>For more information about the DEA Coastlines coastal change statistics or to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description.</a></i></br></br>{{/sce}}{{#year}}<h2 style='font-weight:normal'>{{year}} annual coastline</h2>This line represents the approximate <b>median</b> (i.e. 'dominant') position of the coastline at <b>0 m Above Mean Sea Level</b> across the entire of {{year}}.</br></br><h3 style='font-weight:normal'>{{#wms_aero}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>aerosol issues</b> caused by the 1991 eruption of Mount Pinatubo.</blockquote>{{/wms_aero}}{{#wms_tidal}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>tidal modelling issues</b>, potentially caused by errors in the tidal model used to constrain coastlines to mean sea level, or the influence of shallow intertidal topography that can lead to inaccurate coastline mapping.</blockquote>{{/wms_tidal}}{{#wms_nodata}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>limited good quality satellite observations</b> in this location. This can reduce the quality of resulting coastline features.</blockquote>{{/wms_nodata}}</h3><b>Note: </b><i>Annual coastlines do not reflect short-term coastal variability, for example changes in shoreline position between low and high tide, seasonal effects, or short-lived influences of individual storms. Annual coastlines will therefore show lower variability than the true range of short-term coastal variability at this location.</br></br>For more information about coastline mapping accuracy and limitations or to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines#details'>DEA Coastlines product description.</a></i></br></br>{{/year}}</div>"
                                     },
                                     "legends": [
                                         {
@@ -1404,434 +1374,480 @@
                                         }
                                     ],
                                     "shareKeys": [
-                                        "Root Group/Coastal/Digital Earth Australia Coastlines/Supplementary layers/Rates of change statistics"
+                                        "Root Group/Coastal/Digital Earth Australia Coastlines/Digital Earth Australia Coastlines (beta)"
+                                    ]
+                                },
+                                {
+                                    "id": "uHwXvV",
+                                    "type": "group",
+                                    "name": "Supplementary layers",
+                                    "members": [
+                                        {
+                                            "type": "wms",
+                                            "name": "Annual coastlines",
+                                            "id": "dea_coastlines_annual",
+                                            "shortReport": "<i>Zoom in to view individual annual coastlines from 1988 to the present</i></br></br><small>For more information and to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description</a></small>",
+                                            "url": "https://geoserver.dea.ga.gov.au/geoserver/wms",
+                                            "opacity": 1,
+                                            "layers": "dea:AnnualCoastlines",
+                                            "featureInfoTemplate": {
+                                                "template": "<div style='width:480px'><h2 style='font-weight:normal'>{{year}} annual coastline</h2>This line represents the approximate <b>median</b> (i.e. 'dominant') position of the coastline at <b>0 m Above Mean Sea Level</b> across the entire of {{year}}.</br></br><h3 style='font-weight:normal'>{{#wms_aero}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>aerosol issues</b> caused by the 1991 eruption of Mount Pinatubo.</blockquote>{{/wms_aero}}{{#wms_tidal}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>tidal modelling issues</b>, potentially caused by errors in the tidal model used to constrain coastlines to mean sea level, or the influence of shallow intertidal topography that can lead to inaccurate coastline mapping.</blockquote>{{/wms_tidal}}{{#wms_nodata}}Data quality warning:<blockquote>The accuracy of this coastline may be affected by <b>limited good quality satellite observations</b> in this location. This can reduce the quality of resulting coastline features.</blockquote>{{/wms_nodata}}</h3><b>Note: </b><i>Annual coastlines do not reflect short-term coastal variability, for example changes in shoreline position between low and high tide, seasonal effects, or short-lived influences of individual storms. Annual coastlines will therefore show lower variability than the true range of short-term coastal variability at this location.</br></br>For more information about coastline mapping accuracy and limitations or to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines#details'>DEA Coastlines product description.</a></i></br></br></div>"
+                                            },
+                                            "legends": [
+                                                {
+                                                    "url": "https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_legend 1.png"
+                                                }
+                                            ],
+                                            "shareKeys": [
+                                                "Root Group/Coastal/Digital Earth Australia Coastlines/Supplementary layers/Annual coastlines"
+                                            ]
+                                        },
+                                        {
+                                            "type": "wms",
+                                            "name": "Rates of change statistics",
+                                            "id": "dea_coastlines_statistics",
+                                            "shortReport": "<i>Zoom in to view detailed rates of coastal change along the Australian coastline</i></br></br><small>For more information and to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description</a></small>",
+                                            "url": "https://geoserver.dea.ga.gov.au/geoserver/wms",
+                                            "opacity": 1,
+                                            "chartDisclaimer": "The graph below shows the distance (in metres) from each 1988-2018 coastline to the 2019 coastline. Positive distances indicate that a coastline was located towards the ocean from the 2019 coastline; coastlines with negative distances were located further inland.",
+                                            "layers": "dea:RateOfChangeStatistics",
+                                            "featureInfoTemplate": {
+                                                "template": "<div style='width:480px'><h2 style='font-weight:normal'>This coastline has <b>{{#retreat}}retreated &darr;{{/retreat}}{{#growth}}grown &uarr;{{/growth}}</b> by</br> <b>{{#terria.formatNumber}}{maximumFractionDigits:1}{{rate_time}}{{/terria.formatNumber}} metres (±{{#terria.formatNumber}}{maximumFractionDigits:1}{{conf_time}}{{/terria.formatNumber}}) per year</b></br>on average since <b>1988</b></h2>The coastline at this location was <b>most seaward in {{max_year}}</b>, and <b>most landward in {{min_year}}</b>{{#outl_time}} (excluding outlier years; see below){{/outl_time}}. Since 1988, the median annual position of the coastline has moved over a total distance of approximately <b>{{#terria.formatNumber}}{maximumFractionDigits:0}{{sce}}{{/terria.formatNumber}}  metres.</b></br></br><chart title='DEA Coastlines ({{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.latitude}}{{/terria.formatNumber}}, {{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.longitude}}{{/terria.formatNumber}})' y-column='Distance (metres) relative to 2019 coastline' x-column='Year' column-units='{{terria.timeSeries.units}}' preview-x-label='Year'>Year,Distance (metres) relative to 2019 coastline\n1988,{{dist_1988}}\n1989,{{dist_1989}}\n1990,{{dist_1990}}\n1991,{{dist_1991}}\n1992,{{dist_1992}}\n1993,{{dist_1993}}\n1994,{{dist_1994}}\n1995,{{dist_1995}}\n1996,{{dist_1996}}\n1997,{{dist_1997}}\n1998,{{dist_1998}}\n1999,{{dist_1999}}\n2000,{{dist_2000}}\n2001,{{dist_2001}}\n2002,{{dist_2002}}\n2003,{{dist_2003}}\n2004,{{dist_2004}}\n2005,{{dist_2005}}\n2006,{{dist_2006}}\n2007,{{dist_2007}}\n2008,{{dist_2008}}\n2009,{{dist_2009}}\n2010,{{dist_2010}}\n2011,{{dist_2011}}\n2012,{{dist_2012}}\n2013,{{dist_2013}}\n2014,{{dist_2014}}\n2015,{{dist_2015}}\n2016,{{dist_2016}}\n2017,{{dist_2017}}\n2018,{{dist_2018}}\n2019,{{dist_2019}}</chart>{{#outl_time}}The following years were identified as potential outliers, and should be interpreted with caution:</br></br><b>{{outl_time}}</b></br>{{/outl_time}}</br><b>Note: </b><i>Annual coastline positions shown above represent the median or ‘dominant’ position of the coastline at approximately mean sea level tide (0 m Above Mean Sea Level) for each year. This does not reflect short-term coastal variability, for example changes in shoreline position between low and high tide, seasonal effects, or short-lived influences of individual storms. Annual coastline positions will therefore show lower variability than the true range of short-term coastal variability at this location. </br></br>For more information about the DEA Coastlines coastal change statistics or to download data, visit the <a href='https://cmi.ga.gov.au/data-products/dea/581/dea-coastlines'>DEA Coastlines product description.</a></i></br></br></div>"
+                                            },
+                                            "legends": [
+                                                {
+                                                    "url": "https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_legend 1.png"
+                                                }
+                                            ],
+                                            "shareKeys": [
+                                                "Root Group/Coastal/Digital Earth Australia Coastlines/Supplementary layers/Rates of change statistics"
+                                            ]
+                                        }
+                                    ],
+                                    "shareKeys": [
+                                        "Root Group/Coastal/Digital Earth Australia Coastlines/Supplementary layers"
                                     ]
                                 }
                             ],
                             "shareKeys": [
-                                "Root Group/Coastal/Digital Earth Australia Coastlines/Supplementary layers"
-                            ]
-                        }
-                    ],
-                    "shareKeys": [
-                        "Root Group/Coastal/Digital Earth Australia Coastlines"
-                    ]
-                },
-                {
-                    "id": "bsRRuv",
-                    "type": "group",
-                    "name": "DEA Intertidal (ITEM, NIDEM)",
-                    "members": [
-                        {
-                            "type": "wms",
-                            "name": "DEA Intertidal Elevation (NIDEM)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "NIDEM",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "NIDEM",
-                            "leafletUpdateInterval": 750,
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "bWICtK",
-                            "shareKeys": [
-                                "Root Group/Coastal/National Intertidal Digital Elevation Model"
+                                "Root Group/Coastal/Digital Earth Australia Coastlines"
                             ]
                         },
                         {
-                            "type": "wms",
-                            "name": "DEA Intertidal Extents (ITEM)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ITEM_V2.0.0",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ITEM_V2.0.0",
-                            "leafletUpdateInterval": 750,
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "cXSDLg",
-                            "shareKeys": [
-                                "Root Group/Coastal/Intertidal extent model/Intertidal Extent"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "DEA Intertidal Extents confidence",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ITEM_V2.0.0_Conf",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ITEM_V2.0.0_Conf",
-                            "leafletUpdateInterval": 750,
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "6E5V7V",
-                            "shareKeys": [
-                                "Root Group/Coastal/Intertidal extent model/Intertidal Extent Confidence"
-                            ]
-                        },
-                        {
-                            "type": "geojson",
-                            "name": "DEA Intertidal Extents polygons for data access",
-                            "info": [
+                            "id": "bsRRuv",
+                            "type": "group",
+                            "name": "DEA Intertidal (ITEM, NIDEM)",
+                            "members": [
                                 {
-                                    "name": "Abstract",
-                                    "content": "The Intertidal Extents Model (ITEM v2.0) product analyses GA’s historic archive of satellite imagery to derive a model of the spatial extents of the intertidal zone throughout the tidal cycle. The model can assist in understanding the relative elevation profile of the intertidal zone, delineating exposed areas at differing tidal heights and stages. <p/> The product differs from previous methods used to map the intertidal zone which have been predominately focused on analysing a small number of individual satellite images per location (e.g Ryu et al., 2002; Murray et al., 2012). By utilising a full 30 year time series of observations and a global tidal model (Egbert and Erofeeva, 2002), the methodology enables us to overcome the requirement for clear, high quality observations acquired concurrent to the time of high and low tide."
-                                },
-                                {
-                                    "name": "Overview",
-                                    "content": "The Intertidal Extents Model product is a national scale gridded dataset characterising the spatial extents of the exposed intertidal zone, at intervals of the observed tidal range (Sagar et al. 2017). The current version (2.0) utilises all Landsat observations (5, 7, and 8) for Australian coastal regions (excluding off-shore Territories) between 1986 and 2016 (inclusive). <p/> ITEM v2.0 has implemented an improved tidal modelling framework (see Sagar et al. 2018) over that utilised in ITEM v1.0. The expanded Landsat archive within the Digital Earth Australia (DEA) has also enabled the model extent to be increased to cover a number of offshore reefs, including the full Great Barrier Reef and southern sections of the Torres Strait Islands. The DEA archive and new tidal modelling framework has improved the coverage and quality of the ITEM v2.0 relative extents model, particularly in regions where AGDC cell boundaries in ITEM v1.0 produced discontinuities or the imposed v1.0 cell structure resulted in poor quality tidal modelling (see Sagar et al. 2017). <p/> Examples of regions in ITEM v2.0 where these significant improvements have been noted include: <ul> <li>Dampier Peninsula and King Sound, WA. Improved modelling within King Sound has removed the discontinuities seen at cell boundaries in ITEM v1.0, and expanded the extent of intertidal region being mapped. </li> <li>Tiwi Islands, Coburg Peninsula and Croker Island, NT. Poor spatial representation of the regions tidal regimes in ITEM v1.0 has been improved in v2.0 resulting in extensive onshore reefs and mudflats now being mapped. </li> <li>The full Great Barrier Reef has been mapped, detailing reef structures which expose at low tide. Algorithm amendments have reduced the false positive exposed surface detections resulting from glint and sun glitter. </li> <li>Broad Sound, QLD. Improved tidal modelling has resulted in a smoother intertidal extent map, and a greatly improved confidence layer value for the region. </li> <li>Improvements in the coverage of the DEA archive has allowed many regions unresolved in ITEM v1.0 and showing as 'no data' to be modelled successfully in ITEM 2.0. For example, Mornington Island, QLD, Eastern sections of Fraser Island, QLD and peninsulas in Bowling Green Bay National Park near Townsville, QLD</li> </ul>"
-                                },
-                                {
-                                    "name": "Accuracy and limitations",
-                                    "content": "Due the sun-synchronous nature of the various Landsat sensor observations; it is unlikely that the full physical extents of the tidal range in any cell will be observed. Hence, terminology has been adopted for the product to reflect the highest modelled tide observed in a given cell (HOT) and the lowest modelled tide observed (LOT) (see Sagar et al. 2017). These measures are relative to Mean Sea Level, and have no consistent relationship to Lowest (LAT) and Highest Astronomical Tide (HAT). <p/> The inclusion of the lowest (LMT) and highest (HMT) modelled tide values for each tidal polygon indicates the highest and lowest tides modelled for that location across the full time series by the OTPS model. The relative difference between the LOT and LMT (and HOT and HMT) heights gives an indication of the extent of the tidal range represented in the Relative Extents Model. <p/> As in ITEM v1.0, v2.0 contains some false positive land detection in open ocean regions. These are a function of the lack of data at the extremes of the observed tidal range, and features like glint and undetected cloud in these data poor regions/intervals. <p/> Methods to isolate and remove these features are in development for future versions. Issues in the DEA archive and data noise in the Esperance, WA region off Cape Le Grande and Cape Arid (Polygons 236,201,301) has resulted in significant artefacts in the model, and use of the model in this area is not recommended. <p/> The Confidence layer is designed to assess the reliability of the Relative Extent Model. Within each tidal range percentile interval, the pixel-based standard deviation of the NDWI values for all observations in the interval subset is calculated. The average standard deviation across all tidal range intervals is then calculated and retained as a quality indicator in this product layer. <p/> The Confidence Layer reflects the pixel based consistency of the NDWI values within each subset of observations, based on the tidal range. Higher standard deviation values indicate water classification changes not based on the tidal cycle, and hence lower confidence in the extent model. <p/> Possible drivers of these changes include: <ol> <li>Inadequacies of the tidal model, due perhaps to complex coastal bathymetry or estuarine structures not captured in the model. These effects have been reduced in ITEM v2.0 compared to previous versions, through the use of an improved tidal modelling framework </li> <li>Change in the structure and exposure of water/non-water features NOT driven by tidal variation. For example, movement of sand banks in estuaries, construction of man-made features (ports etc.).</li> <li>Terrestrial/Inland water features not influenced by the tidal cycle.</li> </ol>"
-                                },
-                                {
-                                    "name": "File naming",
-                                    "content": "<h4>THE RELATIVE EXTENTS MODEL v2.0</h4> ITEM_REL_&lt;TIDAL POLYGON NUMBER&gt;_&lt;LONGITUDE&gt;_&lt;LATITUDE&gt; <p/> TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <p/> LONGITUDE is the longitude of the centroid of the tidal polygon <p/> LATITUDE is the latitude of the centroid of the tidal polygon <h4>THE CONFIDENCE LAYER v2.0</h4> ITEM_STD_&lt;TIDAL POLYGON NUMBER&gt;_&lt;LONGITUDE&gt;_&lt;LATITUDE&gt; <p/> TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <p/> LONGITUDE is the longitude of the centroid of the tidal polygon <p/> LATITUDE is the latitude of the centroid of the tidal polygon <p/> The index of downloadable GeoTIFFs can be found here: <p/> <a href='http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalogs/fk4/item_2_0.xml'>http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalogs/fk4/item_2_0.xml</a>"
-                                },
-                                {
-                                    "name": "References",
-                                    "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmos. Oceanic Technol. 19, 183–204. <p/> Murray, N.J., Phinn, S.R., Clemens, R.S., Roelfsema, C.M., Fuller, R.A., 2012. Continental Scale Mapping of Tidal Flats across East Asia Using the Landsat Archive. Remote Sensing 4, 3417–3426. <p/> Ryu, J.-H., Won, J.-S., Min, K.D., 2002. Waterline extraction from Landsat TM data in a tidal flat: A case study in Gomso Bay, Korea. Remote Sensing of Environment 83, 442–456. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sensing of Environment 195, 153–169. <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
-                                }
-                            ],
-                            "url": "https://data.dea.ga.gov.au/ITEM_V2/Itemv2.geojson",
-                            "featureInfoTemplate": {
-                                "template": "The <b>ITEM v2.0 relative model</b> displays the modelled extents of the exposed intertidal zone, at percentile intervals of the observed tidal range (OTR), derived from Landsat imagery acquired between 1986 and 2016. <p/> The full tidal range at this location is {{LMT}} to {{HMT}} metres relative to mean sea level (MSL), and the OTR at this location is between {{LOT}} and {{HOT}} relative to MSL. <p/> The <b>ITEM v2.0 confidence layer</b> displays the standard deviation of the water index values (NDWI) derived across the tidal intervals used in generating the core ITEM relative product. <p/> High values indicate regions where inundation patterns are not driven by tidal influences. This can be a result of change (shoreline, geomorphic, anthropogenic), or caused by errors in the underlying tidal model. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/ITEM_Intervals/ITEM_REL_{{ID}}_{{lon}}_{{lat}}.jpg'/> <figcaption>Coloured bars corresponding to the legend highlight the observations (black dots) and tidal range used to generate each ITEM interval, compared to the full modelled tidal range (light grey) at this location</figcaption> </figure> <p/> Download the GeoTIFF products for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/ITEM/ITEM_2_0/geotiff/ITEM_REL_{{ID}}_{{lon}}_{{lat}}.tif'>ITEM_REL_{{ID}}_{{lon}}_{{lat}}.tif</a> <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/ITEM/ITEM_2_0/geotiff/ITEM_STD_{{ID}}_{{lon}}_{{lat}}.tif'>ITEM_STD_{{ID}}_{{lon}}_{{lat}}.tif</a>",
-                                "formats": {
-                                    "lat": {
-                                        "type": "number",
-                                        "minimumFractionDigits": 2
+                                    "type": "wms",
+                                    "name": "DEA Intertidal Elevation (NIDEM)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "NIDEM",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "NIDEM",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
                                     },
-                                    "lon": {
-                                        "type": "number",
-                                        "minimumFractionDigits": 2
-                                    }
+                                    "id": "bWICtK",
+                                    "shareKeys": [
+                                        "Root Group/Coastal/National Intertidal Digital Elevation Model"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Intertidal Extents (ITEM)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ITEM_V2.0.0",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ITEM_V2.0.0",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "cXSDLg",
+                                    "shareKeys": [
+                                        "Root Group/Coastal/Intertidal extent model/Intertidal Extent"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Intertidal Extents confidence",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ITEM_V2.0.0_Conf",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ITEM_V2.0.0_Conf",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "6E5V7V",
+                                    "shareKeys": [
+                                        "Root Group/Coastal/Intertidal extent model/Intertidal Extent Confidence"
+                                    ]
+                                },
+                                {
+                                    "type": "geojson",
+                                    "name": "DEA Intertidal Extents polygons for data access",
+                                    "info": [
+                                        {
+                                            "name": "Abstract",
+                                            "content": "The Intertidal Extents Model (ITEM v2.0) product analyses GA’s historic archive of satellite imagery to derive a model of the spatial extents of the intertidal zone throughout the tidal cycle. The model can assist in understanding the relative elevation profile of the intertidal zone, delineating exposed areas at differing tidal heights and stages. <p/> The product differs from previous methods used to map the intertidal zone which have been predominately focused on analysing a small number of individual satellite images per location (e.g Ryu et al., 2002; Murray et al., 2012). By utilising a full 30 year time series of observations and a global tidal model (Egbert and Erofeeva, 2002), the methodology enables us to overcome the requirement for clear, high quality observations acquired concurrent to the time of high and low tide."
+                                        },
+                                        {
+                                            "name": "Overview",
+                                            "content": "The Intertidal Extents Model product is a national scale gridded dataset characterising the spatial extents of the exposed intertidal zone, at intervals of the observed tidal range (Sagar et al. 2017). The current version (2.0) utilises all Landsat observations (5, 7, and 8) for Australian coastal regions (excluding off-shore Territories) between 1986 and 2016 (inclusive). <p/> ITEM v2.0 has implemented an improved tidal modelling framework (see Sagar et al. 2018) over that utilised in ITEM v1.0. The expanded Landsat archive within the Digital Earth Australia (DEA) has also enabled the model extent to be increased to cover a number of offshore reefs, including the full Great Barrier Reef and southern sections of the Torres Strait Islands. The DEA archive and new tidal modelling framework has improved the coverage and quality of the ITEM v2.0 relative extents model, particularly in regions where AGDC cell boundaries in ITEM v1.0 produced discontinuities or the imposed v1.0 cell structure resulted in poor quality tidal modelling (see Sagar et al. 2017). <p/> Examples of regions in ITEM v2.0 where these significant improvements have been noted include: <ul> <li>Dampier Peninsula and King Sound, WA. Improved modelling within King Sound has removed the discontinuities seen at cell boundaries in ITEM v1.0, and expanded the extent of intertidal region being mapped. </li> <li>Tiwi Islands, Coburg Peninsula and Croker Island, NT. Poor spatial representation of the regions tidal regimes in ITEM v1.0 has been improved in v2.0 resulting in extensive onshore reefs and mudflats now being mapped. </li> <li>The full Great Barrier Reef has been mapped, detailing reef structures which expose at low tide. Algorithm amendments have reduced the false positive exposed surface detections resulting from glint and sun glitter. </li> <li>Broad Sound, QLD. Improved tidal modelling has resulted in a smoother intertidal extent map, and a greatly improved confidence layer value for the region. </li> <li>Improvements in the coverage of the DEA archive has allowed many regions unresolved in ITEM v1.0 and showing as 'no data' to be modelled successfully in ITEM 2.0. For example, Mornington Island, QLD, Eastern sections of Fraser Island, QLD and peninsulas in Bowling Green Bay National Park near Townsville, QLD</li> </ul>"
+                                        },
+                                        {
+                                            "name": "Accuracy and limitations",
+                                            "content": "Due the sun-synchronous nature of the various Landsat sensor observations; it is unlikely that the full physical extents of the tidal range in any cell will be observed. Hence, terminology has been adopted for the product to reflect the highest modelled tide observed in a given cell (HOT) and the lowest modelled tide observed (LOT) (see Sagar et al. 2017). These measures are relative to Mean Sea Level, and have no consistent relationship to Lowest (LAT) and Highest Astronomical Tide (HAT). <p/> The inclusion of the lowest (LMT) and highest (HMT) modelled tide values for each tidal polygon indicates the highest and lowest tides modelled for that location across the full time series by the OTPS model. The relative difference between the LOT and LMT (and HOT and HMT) heights gives an indication of the extent of the tidal range represented in the Relative Extents Model. <p/> As in ITEM v1.0, v2.0 contains some false positive land detection in open ocean regions. These are a function of the lack of data at the extremes of the observed tidal range, and features like glint and undetected cloud in these data poor regions/intervals. <p/> Methods to isolate and remove these features are in development for future versions. Issues in the DEA archive and data noise in the Esperance, WA region off Cape Le Grande and Cape Arid (Polygons 236,201,301) has resulted in significant artefacts in the model, and use of the model in this area is not recommended. <p/> The Confidence layer is designed to assess the reliability of the Relative Extent Model. Within each tidal range percentile interval, the pixel-based standard deviation of the NDWI values for all observations in the interval subset is calculated. The average standard deviation across all tidal range intervals is then calculated and retained as a quality indicator in this product layer. <p/> The Confidence Layer reflects the pixel based consistency of the NDWI values within each subset of observations, based on the tidal range. Higher standard deviation values indicate water classification changes not based on the tidal cycle, and hence lower confidence in the extent model. <p/> Possible drivers of these changes include: <ol> <li>Inadequacies of the tidal model, due perhaps to complex coastal bathymetry or estuarine structures not captured in the model. These effects have been reduced in ITEM v2.0 compared to previous versions, through the use of an improved tidal modelling framework </li> <li>Change in the structure and exposure of water/non-water features NOT driven by tidal variation. For example, movement of sand banks in estuaries, construction of man-made features (ports etc.).</li> <li>Terrestrial/Inland water features not influenced by the tidal cycle.</li> </ol>"
+                                        },
+                                        {
+                                            "name": "File naming",
+                                            "content": "<h4>THE RELATIVE EXTENTS MODEL v2.0</h4> ITEM_REL_&lt;TIDAL POLYGON NUMBER&gt;_&lt;LONGITUDE&gt;_&lt;LATITUDE&gt; <p/> TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <p/> LONGITUDE is the longitude of the centroid of the tidal polygon <p/> LATITUDE is the latitude of the centroid of the tidal polygon <h4>THE CONFIDENCE LAYER v2.0</h4> ITEM_STD_&lt;TIDAL POLYGON NUMBER&gt;_&lt;LONGITUDE&gt;_&lt;LATITUDE&gt; <p/> TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <p/> LONGITUDE is the longitude of the centroid of the tidal polygon <p/> LATITUDE is the latitude of the centroid of the tidal polygon <p/> The index of downloadable GeoTIFFs can be found here: <p/> <a href='http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalogs/fk4/item_2_0.xml'>http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalogs/fk4/item_2_0.xml</a>"
+                                        },
+                                        {
+                                            "name": "References",
+                                            "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmos. Oceanic Technol. 19, 183–204. <p/> Murray, N.J., Phinn, S.R., Clemens, R.S., Roelfsema, C.M., Fuller, R.A., 2012. Continental Scale Mapping of Tidal Flats across East Asia Using the Landsat Archive. Remote Sensing 4, 3417–3426. <p/> Ryu, J.-H., Won, J.-S., Min, K.D., 2002. Waterline extraction from Landsat TM data in a tidal flat: A case study in Gomso Bay, Korea. Remote Sensing of Environment 83, 442–456. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sensing of Environment 195, 153–169. <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
+                                        }
+                                    ],
+                                    "url": "https://data.dea.ga.gov.au/ITEM_V2/Itemv2.geojson",
+                                    "featureInfoTemplate": {
+                                        "template": "The <b>ITEM v2.0 relative model</b> displays the modelled extents of the exposed intertidal zone, at percentile intervals of the observed tidal range (OTR), derived from Landsat imagery acquired between 1986 and 2016. <p/> The full tidal range at this location is {{LMT}} to {{HMT}} metres relative to mean sea level (MSL), and the OTR at this location is between {{LOT}} and {{HOT}} relative to MSL. <p/> The <b>ITEM v2.0 confidence layer</b> displays the standard deviation of the water index values (NDWI) derived across the tidal intervals used in generating the core ITEM relative product. <p/> High values indicate regions where inundation patterns are not driven by tidal influences. This can be a result of change (shoreline, geomorphic, anthropogenic), or caused by errors in the underlying tidal model. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/ITEM_Intervals/ITEM_REL_{{ID}}_{{lon}}_{{lat}}.jpg'/> <figcaption>Coloured bars corresponding to the legend highlight the observations (black dots) and tidal range used to generate each ITEM interval, compared to the full modelled tidal range (light grey) at this location</figcaption> </figure> <p/> Download the GeoTIFF products for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/ITEM/ITEM_2_0/geotiff/ITEM_REL_{{ID}}_{{lon}}_{{lat}}.tif'>ITEM_REL_{{ID}}_{{lon}}_{{lat}}.tif</a> <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/ITEM/ITEM_2_0/geotiff/ITEM_STD_{{ID}}_{{lon}}_{{lat}}.tif'>ITEM_STD_{{ID}}_{{lon}}_{{lat}}.tif</a>",
+                                        "formats": {
+                                            "lat": {
+                                                "type": "number",
+                                                "minimumFractionDigits": 2
+                                            },
+                                            "lon": {
+                                                "type": "number",
+                                                "minimumFractionDigits": 2
+                                            }
+                                        }
+                                    },
+                                    "id": "6fBRXw",
+                                    "shareKeys": [
+                                        "Root Group/Coastal/Intertidal extent model/Intertidal Extent Polygons data access"
+                                    ]
                                 }
-                            },
-                            "id": "6fBRXw",
+                            ],
+                            "shareKeys": ["Root Group/Coastal/Intertidal extent model"]
+                        },
+                        {
+                            "id": "yC2aqy",
+                            "type": "group",
+                            "name": "DEA High and Low Tide Imagery (HLTC)",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Low Tide Imagery",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "low_tide_composite",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "low_tide_composite",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "4XvQxE",
+                                    "shareKeys": [
+                                        "Root Group/Coastal/Low tide satellite images/Low tide Landsat satellite images"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA High Tide Imagery",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "high_tide_composite",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "high_tide_composite",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "YLrxLi",
+                                    "shareKeys": [
+                                        "Root Group/Coastal/High tide satellite images/High tide Landsat satellite images"
+                                    ]
+                                },
+                                {
+                                    "type": "geojson",
+                                    "name": "DEA Low Tide polygons for data access",
+                                    "info": [
+                                        {
+                                            "name": "Abstract",
+                                            "content": "High Tide and Low Tide Composites 2.0.0 <p/> The High and Low Tide Composites product is composed of two surface reflectance composite mosaics of Landsat TM and ETM+ (Landsat 5 and Landsat 7 respectively) and OLI (Landsat 8) surface reflectance data (Li et al., 2012). These products have been produced using Digital Earth Australia (DEA). The two mosaics allow cloud free and noise reduced visualisation of the shallow water and inter-tidal coastal regions of Australia, as observed at high and low tide respectively (Sagar et al. 2018). <p/> The composites are generated utilising the geomedian approach of Roberts et al (2017) to ensure a valid surface reflectance spectra suitable for uses such as habitat mapping. The time range used for composite generation in each polygon of the mosaic is tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The concepts of the Observed Tidal Range (OTR), and Highest and Lowest Observed Tide (HOT, LOT) are discussed and described fully in Sagar et al. (2017) and the product description for the ITEM v 1.0 product (Geoscience Australia, 2016)."
+                                        },
+                                        {
+                                            "name": "Overview",
+                                            "content": "Inter-tidal zones are difficult regions to characterise due to the dynamic nature of the tide. They are highly changeable environments, subject to forcings from the land, sea and atmosphere and yet they form critical habitats for a wide range of organisms from birds to fish and sea grass. By harnessing the long archive of satellite imagery over Australia's coastal zones in the DEA and pairing the images with regional tidal modelling, the archive can be sorted by tide height rather than date, enabling the inter-tidal zone to be viewed at any stage of the tide regime. <p/> The High Low Tide Composites (HLTC_25) product is composed of two mosaics, distinguished by tide height, representing a composite image of the synthetic geomedian surface reflectance from Landsats 5 TM, Landsat 7 ETM+ and Landsat 8 OLI NBAR data (Li et al., 2012; Roberts et al., 2017). Oregon State Tidal Prediction (OTPS) software (Egbert and Erofeeva, 2002, 2010) was used to generate tide heights, relative to mean sea level, for the Australian continental coastline, split into 306 distinct tidal regions. These time and date stamped tidal values were then attributed to all coastal tile observations for their time of acquisition, creating a range of observed tide heights for the Australian coastline. The two mosaics in HLTC_25 are composited from the highest and lowest 20 % of observed tide in the ensemble and are termed HOT and LOT respectively. A geomedian composite for each Landsat band is calculated from the tiles in each ensemble subset to produce the respective HOT and LOT composites. Note that Landsat 7 ETM+ observations are excluded after May 2003 due to a large number of data artefacts. <p/> The time range used for composite generation in each of the 306 polygons of the mosaics are tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The maximum epoch for which the products are calculated is between 1995-2017, although this varies due to data resolution and observation quality. The product also includes a count of clear observations per pixel for both mosaics and attribute summaries per polygon that include the date range, the highest and lowest modeled astronomical tide as well as the highest and lowest observed tide for that time range, the total observation count and the maximum count of observations for any one pixel in the polygon, the polygon ID number (from 1 to 306), the polygon centroid in longitude and latitude and the count of tide stages attributed to every observation used in that polygon of the mosaic. For the count of tidal stage observations, e = ebbing tide, f = flowing tide, ph = peak high tide and pl = peak low tide. The tide stages were calculated by comparison to the modeled tide data for 15 minutes either side of the observation to determine the ebb, flow or peak movement of the tide. <p/> Observations are filtered to remove poor quality observations including cloud, cloud shadow and band saturation (of any band)."
+                                        },
+                                        {
+                                            "name": "Accuracy and limitations",
+                                            "content": "The accuracy of the tide height data is limited by the accuracy of the OTPS model. Tidal modelling on self-similar coastal polygons was performed to minimise regional uncertainty. <p/> Accuracies and limitations related to geomedian compositing of observations are discussed in Roberts et al (2017). <p/> Users should beware of seasonal and diurnal effects in the imagery, especially in the north east of Australia where the footprint of the highest and lowest astronomical tides are large. Consequently, where image acquisition misses the highest astronomical tide, for example, pooling effects of water are still visible in the landscape in lowest observed tidal composite imagery. <p/> This product has been rendered in both true colour and false colour. Validation and interpretation of surface features has not been attempted here. Interpretation of surface features is at the users own discretion."
+                                        },
+                                        {
+                                            "name": "File naming",
+                                            "content": "`<COUNT OR COMPOSITE>_<HIGH OR LOW>_<TIDAL POLYGON NUMBER>_<LONGITUDE>_<LATITUDE>_<START DATE>_<END DATE>_<PERCENTILE TIDE RANGE>` <p/> COUNT OR COMPOSITE refers to whether pixels contain composite observation values or the count of observations at that pixel location <br/>HIGH OR LOW refers to whether the content relates to High Tide values or Low Tide values <br/>TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <br/>LONGITUDE is the longitude of the centroid of the tidal polygon <br/>LATITUDE is the latitude of the centroid of the tidal polygon <br/>START DATE is the beginning of the date range covered by the file <br/>END DATE is the end of the date range covered by the file <br/>PERCENTILE TIDE RANGE indicates the percentile value used when calculating the composites <p/> The index of downloadable GeoTIFFs can be found here: <p/> http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/catalog.xml"
+                                        },
+                                        {
+                                            "name": "References",
+                                            "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmospheric Ocean. Technol. 19, 183-204. doi:10.1175/1520-0426(2002)019<0183:EIMOBO>2.0.CO;2 <p/> Egbert, G.D., Erofeeva, S.Y., 2010. The OSU TOPEX/Poseiden Global Inverse Solution TPXO [WWW Document]. TPXO8-Atlas Version 10. URL http://volkov.oce.orst.edu/tides/global.html (accessed 2.15.16). <p/> Geoscience Australia, 2016. Intertidal Extents Model (25m) v 1.0 Product Description. doi:10.4225/25/575F683E2A3AF <p/> Li, F., Jupp, D.L.B., Thankappan, M., Lymburner, L., Mueller, N., Lewis, A., Held, A., 2012. A physics-based atmospheric and BRDF correction for Landsat data over mountainous terrain. Remote Sens. Environ. 124, 756-770. doi:10.1016/j.rse.2012.06.018 <p/> Roberts, D., Mueller, N., McIntyre, A., 2017. High-dimensional pixel composites from Earth observation time series. IEEE Trans. Geosci. Remote Sens. In Press. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sens. Environ. 195, 153-169. doi:10.1016/j.rse.2017.04.009 <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
+                                        }
+                                    ],
+                                    "url": "https://data.dea.ga.gov.au/LHTC_Tides/low_composite_20.geojson",
+                                    "featureInfoTemplate": {
+                                        "template": "The tidal range at this location is {{modelLow}} to {{modelHigh}} meters relative to mean sea level (MSL). <p/> The low tide composite at this location was generated from imagery acquired in the lowest 20% of the observed tidal range which is between {{LIT}} and {{HIT}} meters relative to MSL, during the period of time of {{date_range}}. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/LHTC_Tides/COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.jpg'/> <figcaption>Observations used to generate the composite (black dots), in relation to the full modelled tidal range (blue) and complete archive (white dots) at this location</figcaption> </figure> <p/> Download the GeoTIFF for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif'>COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif</a>"
+                                    },
+                                    "id": "5SAK7J",
+                                    "shareKeys": [
+                                        "Root Group/Coastal/Low tide satellite images/Low Tide Polygons for data access"
+                                    ]
+                                },
+                                {
+                                    "type": "geojson",
+                                    "name": "DEA High Tide polygons for data access",
+                                    "info": [
+                                        {
+                                            "name": "Abstract",
+                                            "content": "High Tide and Low Tide Composites 2.0.0 <p/> The High and Low Tide Composites product is composed of two surface reflectance composite mosaics of Landsat TM and ETM+ (Landsat 5 and Landsat 7 respectively) and OLI (Landsat 8) surface reflectance data (Li et al., 2012). These products have been produced using Digital Earth Australia (DEA). The two mosaics allow cloud free and noise reduced visualisation of the shallow water and inter-tidal coastal regions of Australia, as observed at high and low tide respectively (Sagar et al. 2018). <p/> The composites are generated utilising the geomedian approach of Roberts et al (2017) to ensure a valid surface reflectance spectra suitable for uses such as habitat mapping. The time range used for composite generation in each polygon of the mosaic is tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The concepts of the Observed Tidal Range (OTR), and Highest and Lowest Observed Tide (HOT, LOT) are discussed and described fully in Sagar et al. (2017) and the product description for the ITEM v 1.0 product (Geoscience Australia, 2016)."
+                                        },
+                                        {
+                                            "name": "Overview",
+                                            "content": "Inter-tidal zones are difficult regions to characterise due to the dynamic nature of the tide. They are highly changeable environments, subject to forcings from the land, sea and atmosphere and yet they form critical habitats for a wide range of organisms from birds to fish and sea grass. By harnessing the long archive of satellite imagery over Australia's coastal zones in the DEA and pairing the images with regional tidal modelling, the archive can be sorted by tide height rather than date, enabling the inter-tidal zone to be viewed at any stage of the tide regime. <p/> The High Low Tide Composites (HLTC_25) product is composed of two mosaics, distinguished by tide height, representing a composite image of the synthetic geomedian surface reflectance from Landsats 5 TM, Landsat 7 ETM+ and Landsat 8 OLI NBAR data (Li et al., 2012; Roberts et al., 2017). Oregon State Tidal Prediction (OTPS) software (Egbert and Erofeeva, 2002, 2010) was used to generate tide heights, relative to mean sea level, for the Australian continental coastline, split into 306 distinct tidal regions. These time and date stamped tidal values were then attributed to all coastal tile observations for their time of acquisition, creating a range of observed tide heights for the Australian coastline. The two mosaics in HLTC_25 are composited from the highest and lowest 20 % of observed tide in the ensemble and are termed HOT and LOT respectively. A geomedian composite for each Landsat band is calculated from the tiles in each ensemble subset to produce the respective HOT and LOT composites. Note that Landsat 7 ETM+ observations are excluded after May 2003 due to a large number of data artefacts. <p/> The time range used for composite generation in each of the 306 polygons of the mosaics are tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The maximum epoch for which the products are calculated is between 1995-2017, although this varies due to data resolution and observation quality. The product also includes a count of clear observations per pixel for both mosaics and attribute summaries per polygon that include the date range, the highest and lowest modeled astronomical tide as well as the highest and lowest observed tide for that time range, the total observation count and the maximum count of observations for any one pixel in the polygon, the polygon ID number (from 1 to 306), the polygon centroid in longitude and latitude and the count of tide stages attributed to every observation used in that polygon of the mosaic. For the count of tidal stage observations, e = ebbing tide, f = flowing tide, ph = peak high tide and pl = peak low tide. The tide stages were calculated by comparison to the modeled tide data for 15 minutes either side of the observation to determine the ebb, flow or peak movement of the tide. <p/> Observations are filtered to remove poor quality observations including cloud, cloud shadow and band saturation (of any band)."
+                                        },
+                                        {
+                                            "name": "Accuracy and limitations",
+                                            "content": "The accuracy of the tide height data is limited by the accuracy of the OTPS model. Tidal modelling on self-similar coastal polygons was performed to minimise regional uncertainty. <p/> Accuracies and limitations related to geomedian compositing of observations are discussed in Roberts et al (2017). <p/> Users should beware of seasonal and diurnal effects in the imagery, especially in the north east of Australia where the footprint of the highest and lowest astronomical tides are large. Consequently, where image acquisition misses the highest astronomical tide, for example, pooling effects of water are still visible in the landscape in lowest observed tidal composite imagery. <p/> This product has been rendered in both true colour and false colour. Validation and interpretation of surface features has not been attempted here. Interpretation of surface features is at the users own discretion."
+                                        },
+                                        {
+                                            "name": "File naming",
+                                            "content": "`<COUNT OR COMPOSITE>_<HIGH OR LOW>_<TIDAL POLYGON NUMBER>_<LONGITUDE>_<LATITUDE>_<START DATE>_<END DATE>_<PERCENTILE TIDE RANGE>` <p/> COUNT OR COMPOSITE refers to whether pixels contain composite observation values or the count of observations at that pixel location <br/>HIGH OR LOW refers to whether the content relates to High Tide values or Low Tide values <br/>TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <br/>LONGITUDE is the longitude of the centroid of the tidal polygon <br/>LATITUDE is the latitude of the centroid of the tidal polygon <br/>START DATE is the beginning of the date range covered by the file <br/>END DATE is the end of the date range covered by the file <br/>PERCENTILE TIDE RANGE indicates the percentile value used when calculating the composites <p/> The index of downloadable GeoTIFFs can be found here: <p/> http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/catalog.xml"
+                                        },
+                                        {
+                                            "name": "References",
+                                            "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmospheric Ocean. Technol. 19, 183-204. doi:10.1175/1520-0426(2002)019<0183:EIMOBO>2.0.CO;2 <p/> Egbert, G.D., Erofeeva, S.Y., 2010. The OSU TOPEX/Poseiden Global Inverse Solution TPXO [WWW Document]. TPXO8-Atlas Version 10. URL http://volkov.oce.orst.edu/tides/global.html (accessed 2.15.16). <p/> Geoscience Australia, 2016. Intertidal Extents Model (25m) v 1.0 Product Description. doi:10.4225/25/575F683E2A3AF <p/> Li, F., Jupp, D.L.B., Thankappan, M., Lymburner, L., Mueller, N., Lewis, A., Held, A., 2012. A physics-based atmospheric and BRDF correction for Landsat data over mountainous terrain. Remote Sens. Environ. 124, 756-770. doi:10.1016/j.rse.2012.06.018 <p/> Roberts, D., Mueller, N., McIntyre, A., 2017. High-dimensional pixel composites from Earth observation time series. IEEE Trans. Geosci. Remote Sens. In Press. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sens. Environ. 195, 153-169. doi:10.1016/j.rse.2017.04.009 <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
+                                        }
+                                    ],
+                                    "url": "https://data.dea.ga.gov.au/LHTC_Tides/high_composite_20.geojson",
+                                    "featureInfoTemplate": {
+                                        "template": "The tidal range at this location is {{modelLow}} to {{modelHigh}} meters relative to mean sea level (MSL). <p/> The high tide composite at this location was generated from imagery acquired in the top 20% of the observed tidal range which is between {{LIT}} and {{HIT}} meters relative to MSL, during the period of time of {{date_range}}. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/LHTC_Tides/COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.jpg'/> <figcaption>Observations used to generate the composite (black dots), in relation to the full modelled tidal range (blue) and complete archive (white dots) at this location</figcaption> </figure> <p/> Download the GeoTIFF for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif'>COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif</a>"
+                                    },
+                                    "id": "IjP3T7",
+                                    "shareKeys": [
+                                        "Root Group/Coastal/High tide satellite images/High Tide Polygons for data access"
+                                    ]
+                                }
+                            ],
                             "shareKeys": [
-                                "Root Group/Coastal/Intertidal extent model/Intertidal Extent Polygons data access"
+                                "Root Group/Coastal/High tide satellite images"
                             ]
                         }
                     ],
-                    "shareKeys": ["Root Group/Coastal/Intertidal extent model"]
+                    "shareKeys": ["Root Group/Coastal", "Root Group/Sea, ocean and coastline", "Root Group/Sea, ocean and coast"]
                 },
                 {
-                    "id": "yC2aqy",
+                    "id": "UIOgdf",
                     "type": "group",
-                    "name": "DEA High and Low Tide Imagery (HLTC)",
+                    "name": "Hazards",
                     "members": [
                         {
-                            "type": "wms",
-                            "name": "DEA Low Tide Imagery",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "low_tide_composite",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "low_tide_composite",
-                            "leafletUpdateInterval": 750,
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "4XvQxE",
-                            "shareKeys": [
-                                "Root Group/Coastal/Low tide satellite images/Low tide Landsat satellite images"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "DEA High Tide Imagery",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "high_tide_composite",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "high_tide_composite",
-                            "leafletUpdateInterval": 750,
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "YLrxLi",
-                            "shareKeys": [
-                                "Root Group/Coastal/High tide satellite images/High tide Landsat satellite images"
-                            ]
-                        },
-                        {
-                            "type": "geojson",
-                            "name": "DEA Low Tide polygons for data access",
-                            "info": [
+                            "id": "BXljDt",
+                            "type": "group",
+                            "name": "DEA Hotspots",
+                            "members": [
                                 {
-                                    "name": "Abstract",
-                                    "content": "High Tide and Low Tide Composites 2.0.0 <p/> The High and Low Tide Composites product is composed of two surface reflectance composite mosaics of Landsat TM and ETM+ (Landsat 5 and Landsat 7 respectively) and OLI (Landsat 8) surface reflectance data (Li et al., 2012). These products have been produced using Digital Earth Australia (DEA). The two mosaics allow cloud free and noise reduced visualisation of the shallow water and inter-tidal coastal regions of Australia, as observed at high and low tide respectively (Sagar et al. 2018). <p/> The composites are generated utilising the geomedian approach of Roberts et al (2017) to ensure a valid surface reflectance spectra suitable for uses such as habitat mapping. The time range used for composite generation in each polygon of the mosaic is tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The concepts of the Observed Tidal Range (OTR), and Highest and Lowest Observed Tide (HOT, LOT) are discussed and described fully in Sagar et al. (2017) and the product description for the ITEM v 1.0 product (Geoscience Australia, 2016)."
+                                    "type": "wms",
+                                    "name": "DEA Hotspots, Last 72h",
+                                    "url": "https://hotspots.dea.ga.gov.au/geoserver/ows",
+                                    "opacity": 1,
+                                    "layers": "public:hotspots_three_days",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "P5RY1c",
+                                    "shareKeys": [
+                                        "Root Group/Hotspots/Hotspots, Last 72h"
+                                    ]
                                 },
                                 {
-                                    "name": "Overview",
-                                    "content": "Inter-tidal zones are difficult regions to characterise due to the dynamic nature of the tide. They are highly changeable environments, subject to forcings from the land, sea and atmosphere and yet they form critical habitats for a wide range of organisms from birds to fish and sea grass. By harnessing the long archive of satellite imagery over Australia's coastal zones in the DEA and pairing the images with regional tidal modelling, the archive can be sorted by tide height rather than date, enabling the inter-tidal zone to be viewed at any stage of the tide regime. <p/> The High Low Tide Composites (HLTC_25) product is composed of two mosaics, distinguished by tide height, representing a composite image of the synthetic geomedian surface reflectance from Landsats 5 TM, Landsat 7 ETM+ and Landsat 8 OLI NBAR data (Li et al., 2012; Roberts et al., 2017). Oregon State Tidal Prediction (OTPS) software (Egbert and Erofeeva, 2002, 2010) was used to generate tide heights, relative to mean sea level, for the Australian continental coastline, split into 306 distinct tidal regions. These time and date stamped tidal values were then attributed to all coastal tile observations for their time of acquisition, creating a range of observed tide heights for the Australian coastline. The two mosaics in HLTC_25 are composited from the highest and lowest 20 % of observed tide in the ensemble and are termed HOT and LOT respectively. A geomedian composite for each Landsat band is calculated from the tiles in each ensemble subset to produce the respective HOT and LOT composites. Note that Landsat 7 ETM+ observations are excluded after May 2003 due to a large number of data artefacts. <p/> The time range used for composite generation in each of the 306 polygons of the mosaics are tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The maximum epoch for which the products are calculated is between 1995-2017, although this varies due to data resolution and observation quality. The product also includes a count of clear observations per pixel for both mosaics and attribute summaries per polygon that include the date range, the highest and lowest modeled astronomical tide as well as the highest and lowest observed tide for that time range, the total observation count and the maximum count of observations for any one pixel in the polygon, the polygon ID number (from 1 to 306), the polygon centroid in longitude and latitude and the count of tide stages attributed to every observation used in that polygon of the mosaic. For the count of tidal stage observations, e = ebbing tide, f = flowing tide, ph = peak high tide and pl = peak low tide. The tide stages were calculated by comparison to the modeled tide data for 15 minutes either side of the observation to determine the ebb, flow or peak movement of the tide. <p/> Observations are filtered to remove poor quality observations including cloud, cloud shadow and band saturation (of any band)."
-                                },
-                                {
-                                    "name": "Accuracy and limitations",
-                                    "content": "The accuracy of the tide height data is limited by the accuracy of the OTPS model. Tidal modelling on self-similar coastal polygons was performed to minimise regional uncertainty. <p/> Accuracies and limitations related to geomedian compositing of observations are discussed in Roberts et al (2017). <p/> Users should beware of seasonal and diurnal effects in the imagery, especially in the north east of Australia where the footprint of the highest and lowest astronomical tides are large. Consequently, where image acquisition misses the highest astronomical tide, for example, pooling effects of water are still visible in the landscape in lowest observed tidal composite imagery. <p/> This product has been rendered in both true colour and false colour. Validation and interpretation of surface features has not been attempted here. Interpretation of surface features is at the users own discretion."
-                                },
-                                {
-                                    "name": "File naming",
-                                    "content": "`<COUNT OR COMPOSITE>_<HIGH OR LOW>_<TIDAL POLYGON NUMBER>_<LONGITUDE>_<LATITUDE>_<START DATE>_<END DATE>_<PERCENTILE TIDE RANGE>` <p/> COUNT OR COMPOSITE refers to whether pixels contain composite observation values or the count of observations at that pixel location <br/>HIGH OR LOW refers to whether the content relates to High Tide values or Low Tide values <br/>TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <br/>LONGITUDE is the longitude of the centroid of the tidal polygon <br/>LATITUDE is the latitude of the centroid of the tidal polygon <br/>START DATE is the beginning of the date range covered by the file <br/>END DATE is the end of the date range covered by the file <br/>PERCENTILE TIDE RANGE indicates the percentile value used when calculating the composites <p/> The index of downloadable GeoTIFFs can be found here: <p/> http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/catalog.xml"
-                                },
-                                {
-                                    "name": "References",
-                                    "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmospheric Ocean. Technol. 19, 183-204. doi:10.1175/1520-0426(2002)019<0183:EIMOBO>2.0.CO;2 <p/> Egbert, G.D., Erofeeva, S.Y., 2010. The OSU TOPEX/Poseiden Global Inverse Solution TPXO [WWW Document]. TPXO8-Atlas Version 10. URL http://volkov.oce.orst.edu/tides/global.html (accessed 2.15.16). <p/> Geoscience Australia, 2016. Intertidal Extents Model (25m) v 1.0 Product Description. doi:10.4225/25/575F683E2A3AF <p/> Li, F., Jupp, D.L.B., Thankappan, M., Lymburner, L., Mueller, N., Lewis, A., Held, A., 2012. A physics-based atmospheric and BRDF correction for Landsat data over mountainous terrain. Remote Sens. Environ. 124, 756-770. doi:10.1016/j.rse.2012.06.018 <p/> Roberts, D., Mueller, N., McIntyre, A., 2017. High-dimensional pixel composites from Earth observation time series. IEEE Trans. Geosci. Remote Sens. In Press. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sens. Environ. 195, 153-169. doi:10.1016/j.rse.2017.04.009 <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
+                                    "type": "wms",
+                                    "name": "Himawari-8 Mosaic, Last 10m",
+                                    "url": "https://hotspots.dea.ga.gov.au/geoserver/ows",
+                                    "opacity": 1,
+                                    "layers": "public:himawari8_mosaic",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "m5lE5k",
+                                    "shareKeys": [
+                                        "Root Group/Hotspots/Himawari-8 Mosaic, Last 10m"
+                                    ]
                                 }
                             ],
-                            "url": "https://data.dea.ga.gov.au/LHTC_Tides/low_composite_20.geojson",
-                            "featureInfoTemplate": {
-                                "template": "The tidal range at this location is {{modelLow}} to {{modelHigh}} meters relative to mean sea level (MSL). <p/> The low tide composite at this location was generated from imagery acquired in the lowest 20% of the observed tidal range which is between {{LIT}} and {{HIT}} meters relative to MSL, during the period of time of {{date_range}}. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/LHTC_Tides/COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.jpg'/> <figcaption>Observations used to generate the composite (black dots), in relation to the full modelled tidal range (blue) and complete archive (white dots) at this location</figcaption> </figure> <p/> Download the GeoTIFF for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif'>COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif</a>"
-                            },
-                            "id": "5SAK7J",
-                            "shareKeys": [
-                                "Root Group/Coastal/Low tide satellite images/Low Tide Polygons for data access"
-                            ]
-                        },
-                        {
-                            "type": "geojson",
-                            "name": "DEA High Tide polygons for data access",
-                            "info": [
-                                {
-                                    "name": "Abstract",
-                                    "content": "High Tide and Low Tide Composites 2.0.0 <p/> The High and Low Tide Composites product is composed of two surface reflectance composite mosaics of Landsat TM and ETM+ (Landsat 5 and Landsat 7 respectively) and OLI (Landsat 8) surface reflectance data (Li et al., 2012). These products have been produced using Digital Earth Australia (DEA). The two mosaics allow cloud free and noise reduced visualisation of the shallow water and inter-tidal coastal regions of Australia, as observed at high and low tide respectively (Sagar et al. 2018). <p/> The composites are generated utilising the geomedian approach of Roberts et al (2017) to ensure a valid surface reflectance spectra suitable for uses such as habitat mapping. The time range used for composite generation in each polygon of the mosaic is tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The concepts of the Observed Tidal Range (OTR), and Highest and Lowest Observed Tide (HOT, LOT) are discussed and described fully in Sagar et al. (2017) and the product description for the ITEM v 1.0 product (Geoscience Australia, 2016)."
-                                },
-                                {
-                                    "name": "Overview",
-                                    "content": "Inter-tidal zones are difficult regions to characterise due to the dynamic nature of the tide. They are highly changeable environments, subject to forcings from the land, sea and atmosphere and yet they form critical habitats for a wide range of organisms from birds to fish and sea grass. By harnessing the long archive of satellite imagery over Australia's coastal zones in the DEA and pairing the images with regional tidal modelling, the archive can be sorted by tide height rather than date, enabling the inter-tidal zone to be viewed at any stage of the tide regime. <p/> The High Low Tide Composites (HLTC_25) product is composed of two mosaics, distinguished by tide height, representing a composite image of the synthetic geomedian surface reflectance from Landsats 5 TM, Landsat 7 ETM+ and Landsat 8 OLI NBAR data (Li et al., 2012; Roberts et al., 2017). Oregon State Tidal Prediction (OTPS) software (Egbert and Erofeeva, 2002, 2010) was used to generate tide heights, relative to mean sea level, for the Australian continental coastline, split into 306 distinct tidal regions. These time and date stamped tidal values were then attributed to all coastal tile observations for their time of acquisition, creating a range of observed tide heights for the Australian coastline. The two mosaics in HLTC_25 are composited from the highest and lowest 20 % of observed tide in the ensemble and are termed HOT and LOT respectively. A geomedian composite for each Landsat band is calculated from the tiles in each ensemble subset to produce the respective HOT and LOT composites. Note that Landsat 7 ETM+ observations are excluded after May 2003 due to a large number of data artefacts. <p/> The time range used for composite generation in each of the 306 polygons of the mosaics are tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The maximum epoch for which the products are calculated is between 1995-2017, although this varies due to data resolution and observation quality. The product also includes a count of clear observations per pixel for both mosaics and attribute summaries per polygon that include the date range, the highest and lowest modeled astronomical tide as well as the highest and lowest observed tide for that time range, the total observation count and the maximum count of observations for any one pixel in the polygon, the polygon ID number (from 1 to 306), the polygon centroid in longitude and latitude and the count of tide stages attributed to every observation used in that polygon of the mosaic. For the count of tidal stage observations, e = ebbing tide, f = flowing tide, ph = peak high tide and pl = peak low tide. The tide stages were calculated by comparison to the modeled tide data for 15 minutes either side of the observation to determine the ebb, flow or peak movement of the tide. <p/> Observations are filtered to remove poor quality observations including cloud, cloud shadow and band saturation (of any band)."
-                                },
-                                {
-                                    "name": "Accuracy and limitations",
-                                    "content": "The accuracy of the tide height data is limited by the accuracy of the OTPS model. Tidal modelling on self-similar coastal polygons was performed to minimise regional uncertainty. <p/> Accuracies and limitations related to geomedian compositing of observations are discussed in Roberts et al (2017). <p/> Users should beware of seasonal and diurnal effects in the imagery, especially in the north east of Australia where the footprint of the highest and lowest astronomical tides are large. Consequently, where image acquisition misses the highest astronomical tide, for example, pooling effects of water are still visible in the landscape in lowest observed tidal composite imagery. <p/> This product has been rendered in both true colour and false colour. Validation and interpretation of surface features has not been attempted here. Interpretation of surface features is at the users own discretion."
-                                },
-                                {
-                                    "name": "File naming",
-                                    "content": "`<COUNT OR COMPOSITE>_<HIGH OR LOW>_<TIDAL POLYGON NUMBER>_<LONGITUDE>_<LATITUDE>_<START DATE>_<END DATE>_<PERCENTILE TIDE RANGE>` <p/> COUNT OR COMPOSITE refers to whether pixels contain composite observation values or the count of observations at that pixel location <br/>HIGH OR LOW refers to whether the content relates to High Tide values or Low Tide values <br/>TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <br/>LONGITUDE is the longitude of the centroid of the tidal polygon <br/>LATITUDE is the latitude of the centroid of the tidal polygon <br/>START DATE is the beginning of the date range covered by the file <br/>END DATE is the end of the date range covered by the file <br/>PERCENTILE TIDE RANGE indicates the percentile value used when calculating the composites <p/> The index of downloadable GeoTIFFs can be found here: <p/> http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/catalog.xml"
-                                },
-                                {
-                                    "name": "References",
-                                    "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmospheric Ocean. Technol. 19, 183-204. doi:10.1175/1520-0426(2002)019<0183:EIMOBO>2.0.CO;2 <p/> Egbert, G.D., Erofeeva, S.Y., 2010. The OSU TOPEX/Poseiden Global Inverse Solution TPXO [WWW Document]. TPXO8-Atlas Version 10. URL http://volkov.oce.orst.edu/tides/global.html (accessed 2.15.16). <p/> Geoscience Australia, 2016. Intertidal Extents Model (25m) v 1.0 Product Description. doi:10.4225/25/575F683E2A3AF <p/> Li, F., Jupp, D.L.B., Thankappan, M., Lymburner, L., Mueller, N., Lewis, A., Held, A., 2012. A physics-based atmospheric and BRDF correction for Landsat data over mountainous terrain. Remote Sens. Environ. 124, 756-770. doi:10.1016/j.rse.2012.06.018 <p/> Roberts, D., Mueller, N., McIntyre, A., 2017. High-dimensional pixel composites from Earth observation time series. IEEE Trans. Geosci. Remote Sens. In Press. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sens. Environ. 195, 153-169. doi:10.1016/j.rse.2017.04.009 <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
-                                }
-                            ],
-                            "url": "https://data.dea.ga.gov.au/LHTC_Tides/high_composite_20.geojson",
-                            "featureInfoTemplate": {
-                                "template": "The tidal range at this location is {{modelLow}} to {{modelHigh}} meters relative to mean sea level (MSL). <p/> The high tide composite at this location was generated from imagery acquired in the top 20% of the observed tidal range which is between {{LIT}} and {{HIT}} meters relative to MSL, during the period of time of {{date_range}}. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/LHTC_Tides/COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.jpg'/> <figcaption>Observations used to generate the composite (black dots), in relation to the full modelled tidal range (blue) and complete archive (white dots) at this location</figcaption> </figure> <p/> Download the GeoTIFF for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif'>COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif</a>"
-                            },
-                            "id": "IjP3T7",
-                            "shareKeys": [
-                                "Root Group/Coastal/High tide satellite images/High Tide Polygons for data access"
-                            ]
-                        }
-                    ],
-                    "shareKeys": [
-                        "Root Group/Coastal/High tide satellite images"
-                    ]
-                }
-            ],
-            "shareKeys": ["Root Group/Coastal", "Root Group/Sea, ocean and coastline", "Root Group/Sea, ocean and coast"]
-        },
-        {
-            "id": "UIOgdf",
-            "type": "group",
-            "name": "Hazards",
-            "members": [
-                {
-                    "id": "BXljDt",
-                    "type": "group",
-                    "name": "DEA Hotspots",
-                    "members": [
-                        {
-                            "type": "wms",
-                            "name": "DEA Hotspots, Last 72h",
-                            "url": "https://hotspots.dea.ga.gov.au/geoserver/ows",
-                            "opacity": 1,
-                            "layers": "public:hotspots_three_days",
-                            "leafletUpdateInterval": 750,
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "P5RY1c",
-                            "shareKeys": [
-                                "Root Group/Hotspots/Hotspots, Last 72h"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "Himawari-8 Mosaic, Last 10m",
-                            "url": "https://hotspots.dea.ga.gov.au/geoserver/ows",
-                            "opacity": 1,
-                            "layers": "public:himawari8_mosaic",
-                            "leafletUpdateInterval": 750,
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "m5lE5k",
-                            "shareKeys": [
-                                "Root Group/Hotspots/Himawari-8 Mosaic, Last 10m"
-                            ]
+                            "shareKeys": ["Root Group/Hotspots"]
                         }
                     ],
                     "shareKeys": ["Root Group/Hotspots"]
-                }
-            ],
-            "shareKeys": ["Root Group/Hotspots"]
-        },
-        {
-            "id": "89bGRF",
-            "type": "group",
-            "name": "Other",
-            "members": [
+                },
                 {
-                    "id": "jqk1GN",
+                    "id": "89bGRF",
                     "type": "group",
-                    "name": "Camden Environmental Monitoring Project InSAR",
+                    "name": "Other",
                     "members": [
                         {
-                            "type": "wms",
-                            "name": "ALOS Displacement",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "alos_displacement",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "alos_displacement",
-                            "chartColor": "white",
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "{{#data}}<table><tr><td>Displacement up-down</td><td>{{bands.ud}} mm</td></tr><tr><td>Displacement east-west</td><td>{{bands.ew}} mm</td></tr><tr><td>Displacement uncertainty up-down</td><td>{{bands.upstd}} mm</td></tr><tr><td>Displacement uncertainty east-west</td><td>{{bands.ewstd}} mm</td></tr></table>{{/data}}{{#data_links}}<a href='{{data_links}}'>Link to data</a>{{/data_links}}"
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "DzhvUP",
+                            "id": "jqk1GN",
+                            "type": "group",
+                            "name": "Camden Environmental Monitoring Project InSAR",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "ALOS Displacement",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "alos_displacement",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "alos_displacement",
+                                    "chartColor": "white",
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "{{#data}}<table><tr><td>Displacement up-down</td><td>{{bands.ud}} mm</td></tr><tr><td>Displacement east-west</td><td>{{bands.ew}} mm</td></tr><tr><td>Displacement uncertainty up-down</td><td>{{bands.upstd}} mm</td></tr><tr><td>Displacement uncertainty east-west</td><td>{{bands.ewstd}} mm</td></tr></table>{{/data}}{{#data_links}}<a href='{{data_links}}'>Link to data</a>{{/data_links}}"
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "DzhvUP",
+                                    "shareKeys": [
+                                        "Root Group/Camden Environmental Monitoring Project InSAR/ALOS Displacement"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "ALOS Velocity",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "alos_velocity",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "alos_velocity",
+                                    "chartColor": "white",
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "{{#data}}<table><tr><td>Velocity up-down</td><td>{{bands.ud}} mm/year</td></tr><tr><td>Velocity east-west</td><td>{{bands.ew}} mm/year</td></tr><tr><td>Velocity uncertainty up-down</td><td>{{bands.upstd}} mm/year</td></tr><tr><td>Velocity uncertainty east-west</td><td>{{bands.ewstd}} mm/year</td></tr></table>{{/data}}{{#data_links}}<a href='{{data_links}}'>Link to data</a>{{/data_links}}"
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "KqwIfB",
+                                    "shareKeys": [
+                                        "Root Group/Camden Environmental Monitoring Project InSAR/ALOS Velocity"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "ENVISAT Displacement",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "envisat_displacement",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "envisat_displacement",
+                                    "chartColor": "white",
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "{{#data}}<table><tr><td>Displacement up-down</td><td>{{bands.ud}} mm</td></tr><tr><td>Displacement east-west</td><td>{{bands.ew}} mm</td></tr><tr><td>Displacement uncertainty up-down</td><td>{{bands.upstd}} mm</td></tr><tr><td>Displacement uncertainty east-west</td><td>{{bands.ewstd}} mm</td></tr></table>{{/data}}{{#data_links}}<a href='{{data_links}}'>Link to data</a>{{/data_links}}"
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "Sc8euJ",
+                                    "shareKeys": [
+                                        "Root Group/Camden Environmental Monitoring Project InSAR/ENVISAT Displacement"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "ENVISAT Velocity",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "envisat_velocity",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "envisat_velocity",
+                                    "chartColor": "white",
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "{{#data}}<table><tr><td>Velocity up-down</td><td>{{bands.ud}} mm/year</td></tr><tr><td>Velocity east-west</td><td>{{bands.ew}} mm/year</td></tr><tr><td>Velocity uncertainty up-down</td><td>{{bands.upstd}} mm/year</td></tr><tr><td>Velocity uncertainty east-west</td><td>{{bands.ewstd}} mm/year</td></tr></table>{{/data}}{{#data_links}}<a href='{{data_links}}'>Link to data</a>{{/data_links}}"
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "qzCczV",
+                                    "shareKeys": [
+                                        "Root Group/Camden Environmental Monitoring Project InSAR/ENVISAT Velocity"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "RADARSAT2 Displacement",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "radarsat2_displacement",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "radarsat2_displacement",
+                                    "chartColor": "white",
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "{{#data}}<table><tr><td>Displacement up-down</td><td>{{bands.ud}} mm</td></tr><tr><td>Displacement east-west</td><td>{{bands.ew}} mm</td></tr><tr><td>Displacement uncertainty up-down</td><td>{{bands.upstd}} mm</td></tr><tr><td>Displacement uncertainty east-west</td><td>{{bands.ewstd}} mm</td></tr></table>{{/data}}{{#data_links}}<a href='{{data_links}}'>Link to data</a>{{/data_links}}"
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "Nb5Pcu",
+                                    "shareKeys": [
+                                        "Root Group/Camden Environmental Monitoring Project InSAR/RADARSAT2 Displacement"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "RADARSAT2 Velocity",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "radarsat2_velocity",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "radarsat2_velocity",
+                                    "chartColor": "white",
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "{{#data}}<table><tr><td>Velocity up-down</td><td>{{bands.ud}} mm/year</td></tr><tr><td>Velocity east-west</td><td>{{bands.ew}} mm/year</td></tr><tr><td>Velocity uncertainty up-down</td><td>{{bands.upstd}} mm/year</td></tr><tr><td>Velocity uncertainty east-west</td><td>{{bands.ewstd}} mm/year</td></tr></table>{{/data}}{{#data_links}}<a href='{{data_links}}'>Link to data</a>{{/data_links}}"
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "3mQ5Ye",
+                                    "shareKeys": [
+                                        "Root Group/Camden Environmental Monitoring Project InSAR/RADARSAT2 Velocity"
+                                    ]
+                                }
+                            ],
+                            "info": [
+                                {
+                                    "name": "Details",
+                                    "content": "These InSAR-derived datasets were produced by Geoscience Australia under the Camden Environmental Monitoring Project.\nProducts are given for three separately processed satellite radar datasets: ALOS, Envisat and Radarsat-2.\nProducts are derived in up-down and east-west direction from combination of different viewing geometries of the same satellite sensor. The slanted InSAR line-of-sight viewing geometry is insensitive to the north-south direction.\nNegative signals indicate either downward (in up-down products) or westward (in east-west products) surface movements.\nUncertainties of each product result from error propagation of initial line-of-sight data uncertainties during the data combination step.\nThe InSAR processing method used to create these products only uses high-quality pixels with very little signal noise. The resulting products are sparse in some areas (particularly highly vegetated areas) but have a high accuracy as demonstrated by validation with GPS data described in the GA Record. Different InSAR processing methods could be used to retrieve a denser coverage of displacement and velocity observations, but with reduced accuracy.\nALOS products generally have denser spatial coverage than Envisat and Radarsat-2 products. This is because ALOS uses a longer radar wavelength (~24 cm) than Envisat and Radarsat-2 (~6 cm) which enables the radar to better penetrate vegetation.\nA full description of the project and methods used to derive these InSAR products is given in the associated GA Record."
+                                }
+                            ],
                             "shareKeys": [
-                                "Root Group/Camden Environmental Monitoring Project InSAR/ALOS Displacement"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "ALOS Velocity",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "alos_velocity",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "alos_velocity",
-                            "chartColor": "white",
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "{{#data}}<table><tr><td>Velocity up-down</td><td>{{bands.ud}} mm/year</td></tr><tr><td>Velocity east-west</td><td>{{bands.ew}} mm/year</td></tr><tr><td>Velocity uncertainty up-down</td><td>{{bands.upstd}} mm/year</td></tr><tr><td>Velocity uncertainty east-west</td><td>{{bands.ewstd}} mm/year</td></tr></table>{{/data}}{{#data_links}}<a href='{{data_links}}'>Link to data</a>{{/data_links}}"
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "KqwIfB",
-                            "shareKeys": [
-                                "Root Group/Camden Environmental Monitoring Project InSAR/ALOS Velocity"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "ENVISAT Displacement",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "envisat_displacement",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "envisat_displacement",
-                            "chartColor": "white",
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "{{#data}}<table><tr><td>Displacement up-down</td><td>{{bands.ud}} mm</td></tr><tr><td>Displacement east-west</td><td>{{bands.ew}} mm</td></tr><tr><td>Displacement uncertainty up-down</td><td>{{bands.upstd}} mm</td></tr><tr><td>Displacement uncertainty east-west</td><td>{{bands.ewstd}} mm</td></tr></table>{{/data}}{{#data_links}}<a href='{{data_links}}'>Link to data</a>{{/data_links}}"
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "Sc8euJ",
-                            "shareKeys": [
-                                "Root Group/Camden Environmental Monitoring Project InSAR/ENVISAT Displacement"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "ENVISAT Velocity",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "envisat_velocity",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "envisat_velocity",
-                            "chartColor": "white",
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "{{#data}}<table><tr><td>Velocity up-down</td><td>{{bands.ud}} mm/year</td></tr><tr><td>Velocity east-west</td><td>{{bands.ew}} mm/year</td></tr><tr><td>Velocity uncertainty up-down</td><td>{{bands.upstd}} mm/year</td></tr><tr><td>Velocity uncertainty east-west</td><td>{{bands.ewstd}} mm/year</td></tr></table>{{/data}}{{#data_links}}<a href='{{data_links}}'>Link to data</a>{{/data_links}}"
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "qzCczV",
-                            "shareKeys": [
-                                "Root Group/Camden Environmental Monitoring Project InSAR/ENVISAT Velocity"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "RADARSAT2 Displacement",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "radarsat2_displacement",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "radarsat2_displacement",
-                            "chartColor": "white",
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "{{#data}}<table><tr><td>Displacement up-down</td><td>{{bands.ud}} mm</td></tr><tr><td>Displacement east-west</td><td>{{bands.ew}} mm</td></tr><tr><td>Displacement uncertainty up-down</td><td>{{bands.upstd}} mm</td></tr><tr><td>Displacement uncertainty east-west</td><td>{{bands.ewstd}} mm</td></tr></table>{{/data}}{{#data_links}}<a href='{{data_links}}'>Link to data</a>{{/data_links}}"
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "Nb5Pcu",
-                            "shareKeys": [
-                                "Root Group/Camden Environmental Monitoring Project InSAR/RADARSAT2 Displacement"
-                            ]
-                        },
-                        {
-                            "type": "wms",
-                            "name": "RADARSAT2 Velocity",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "radarsat2_velocity",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "radarsat2_velocity",
-                            "chartColor": "white",
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "{{#data}}<table><tr><td>Velocity up-down</td><td>{{bands.ud}} mm/year</td></tr><tr><td>Velocity east-west</td><td>{{bands.ew}} mm/year</td></tr><tr><td>Velocity uncertainty up-down</td><td>{{bands.upstd}} mm/year</td></tr><tr><td>Velocity uncertainty east-west</td><td>{{bands.ewstd}} mm/year</td></tr></table>{{/data}}{{#data_links}}<a href='{{data_links}}'>Link to data</a>{{/data_links}}"
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "3mQ5Ye",
-                            "shareKeys": [
-                                "Root Group/Camden Environmental Monitoring Project InSAR/RADARSAT2 Velocity"
+                                "Root Group/Camden Environmental Monitoring Project InSAR"
                             ]
                         }
                     ],
-                    "info": [
-                        {
-                            "name": "Details",
-                            "content": "These InSAR-derived datasets were produced by Geoscience Australia under the Camden Environmental Monitoring Project.\nProducts are given for three separately processed satellite radar datasets: ALOS, Envisat and Radarsat-2.\nProducts are derived in up-down and east-west direction from combination of different viewing geometries of the same satellite sensor. The slanted InSAR line-of-sight viewing geometry is insensitive to the north-south direction.\nNegative signals indicate either downward (in up-down products) or westward (in east-west products) surface movements.\nUncertainties of each product result from error propagation of initial line-of-sight data uncertainties during the data combination step.\nThe InSAR processing method used to create these products only uses high-quality pixels with very little signal noise. The resulting products are sparse in some areas (particularly highly vegetated areas) but have a high accuracy as demonstrated by validation with GPS data described in the GA Record. Different InSAR processing methods could be used to retrieve a denser coverage of displacement and velocity observations, but with reduced accuracy.\nALOS products generally have denser spatial coverage than Envisat and Radarsat-2 products. This is because ALOS uses a longer radar wavelength (~24 cm) than Envisat and Radarsat-2 (~6 cm) which enables the radar to better penetrate vegetation.\nA full description of the project and methods used to derive these InSAR products is given in the associated GA Record."
-                        }
-                    ],
-                    "shareKeys": [
-                        "Root Group/Camden Environmental Monitoring Project InSAR"
-                    ]
+                    "shareKeys": ["Root Group/Other"]
                 }
             ],
-            "shareKeys": ["Root Group/Other"]
-        }
-    ],
     "corsDomains": [
         "dea.ga.gov.au",
         "hotspots.dea.ga.gov.au",


### PR DESCRIPTION
This PR implments the changes made on Terria Cube in #855 on DEA Maps.

From the look of it, this PR also adds in recent changes to make sure annual products are formatted in `"dateFormat": "'Year: 'yyyy",`.

(again, the re-ordering has made the diff hard to read, but the config has been tested working on DEA Maps).