### PR TITLE
Remove the rgba section, no rgba.tif as output

### DIFF
--- a/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml
+++ b/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml
@@ -68,7 +68,3 @@ s3_acl: public-read
 # Generic product attributes
 cog_opts:
   zlevel: 9
-  overrides:
-    rgba:
-      compress: JPEG
-      jpeg_quality: 90


### PR DESCRIPTION
Remove the rgba section in Geomedian config. The `opendatacube/datacube-statistician:0.3.42` will not generate rgba.tif as output file.