### PR TITLE
Update wo summary product names

### DIFF
--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_apr_oct_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_apr_oct_3.yaml
@@ -1,9 +1,9 @@
 plugin: wofs-summary # this can help system find the relative plugin and plugin version
 product:
   name: ga_ls_wo_fq_apr_oct_3
-  short_name: ga_ls_wo_fq_apr_oct_3
+  short_name: Water Observations April to October (Landsat)
   version: 1.6.0
-  product_family: wo_summary
+  product_family: DEA Water Observations (WOfS)
 
   # -- EO Dataset3 relative section --
   naming_conventions_values: dea_c3
@@ -96,7 +96,3 @@ s3_acl: public-read
 # Generic product attributes
 cog_opts:
   zlevel: 9
-  overrides:
-    rgba:
-      compress: JPEG
-      jpeg_quality: 90

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_cyear_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_cyear_3.yaml
@@ -1,9 +1,9 @@
 plugin: wofs-summary # this can help system find the relative plugin and plugin version
 product:
-  name: ga_ls_fq_cyear_3
-  short_name: ga_ls_fq_cyear_3
+  name: ga_ls_wo_fq_cyear_3
+  short_name: Water Observations Calendar Year (Landsat)
   version: 1.6.0
-  product_family: wo_summary
+  product_family: DEA Water Observations (WOfS)
 
   # -- EO Dataset3 relative section --
   naming_conventions_values: dea_c3
@@ -103,7 +103,3 @@ s3_acl: public-read
 # Generic product attributes
 cog_opts:
   zlevel: 9
-  overrides:
-    rgba:
-      compress: JPEG
-      jpeg_quality: 90

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_fyear_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_fyear_3.yaml
@@ -1,9 +1,9 @@
 plugin: wofs-summary # this can help system find the relative plugin and plugin version
 product:
   name: ga_ls_wo_fq_fyear_3
-  short_name: ga_ls_wo_fq_fyear_3
+  short_name: Water Observations Financial Year (Landsat)
   version: 1.6.0
-  product_family: wo_summary
+  product_family: DEA Water Observations (WOfS)
 
   # -- EO Dataset3 relative section --
   naming_conventions_values: dea_c3
@@ -103,7 +103,3 @@ s3_acl: public-read
 # Generic product attributes
 cog_opts:
   zlevel: 9
-  overrides:
-    rgba:
-      compress: JPEG
-      jpeg_quality: 90

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_myear_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_myear_3.yaml
@@ -1,9 +1,9 @@
 plugin: wofs-summary-fh # this can help system find the relative plugin and plugin version
 product:
   name: ga_ls_wo_fq_myear_3
-  short_name: ga_ls_wo_fq_myear_3
+  short_name: Water Observations Multi Year (Landsat)
   version: 1.6.0
-  product_family: wo_summary
+  product_family: DEA Water Observations (WOfS)
 
   # -- EO Dataset3 relative section --
   naming_conventions_values: dea_c3
@@ -103,7 +103,3 @@ s3_acl: public-read
 # Generic product attributes
 cog_opts:
   zlevel: 9
-  overrides:
-    rgba:
-      compress: JPEG
-      jpeg_quality: 90

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_nov_mar_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_nov_mar_3.yaml
@@ -1,9 +1,9 @@
 plugin: wofs-summary # this can help system find the relative plugin and plugin version
 product:
   name: ga_ls_wo_fq_nov_mar_3
-  short_name: ga_ls_wo_fq_nov_mar_3
+  short_name: Water Observations November to March (Landsat)
   version: 1.6.0
-  product_family: wo_summary
+  product_family: DEA Water Observations (WOfS)
 
   # -- EO Dataset3 relative section --
   naming_conventions_values: dea_c3
@@ -96,7 +96,3 @@ s3_acl: public-read
 # Generic product attributes
 cog_opts:
   zlevel: 9
-  overrides:
-    rgba:
-      compress: JPEG
-      jpeg_quality: 90


### PR DESCRIPTION
Based on Simon's feedback. Fix:

1. copy short names from product doc to config files
2. update calendar year product name from: `ga_ls_fq_cyear_3` to `ga_ls_wo_fq_cyear_3`
3. remove all rgba sections in config files. Then no rgba.tif as output in WO Summary