### PR TITLE
Skip more landsat properties in output dataset

### DIFF
--- a/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
+++ b/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
@@ -42,6 +42,10 @@ product:
     - gqa:cep90
     - landsat:landsat_product_id
     - landsat:landsat_scene_id
+    - landsat:collection_category
+    - landsat:collection_number
+    - landsat:wrs_path
+    - landsat:wrs_row
 
   preview_image_ows_style:
     name: fc_rgb

--- a/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_fyear_3.yaml
+++ b/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_fyear_3.yaml
@@ -42,6 +42,10 @@ product:
     - gqa:cep90
     - landsat:landsat_product_id
     - landsat:landsat_scene_id
+    - landsat:collection_category
+    - landsat:collection_number
+    - landsat:wrs_path
+    - landsat:wrs_row
 
   preview_image_ows_style:
     name: fc_rgb

--- a/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml
+++ b/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml
@@ -42,6 +42,10 @@ product:
     - gqa:cep90
     - landsat:landsat_product_id
     - landsat:landsat_scene_id
+    - landsat:collection_category
+    - landsat:collection_number
+    - landsat:wrs_path
+    - landsat:wrs_row
 
   preview_image_ows_style:
     name: simple_rgb

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_apr_oct_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_apr_oct_3.yaml
@@ -42,6 +42,10 @@ product:
     - gqa:cep90
     - landsat:landsat_product_id
     - landsat:landsat_scene_id
+    - landsat:collection_category
+    - landsat:collection_number
+    - landsat:wrs_path
+    - landsat:wrs_row
 
   preview_image_ows_style:
     name: seasonal_WOfS_frequency

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_cyear_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_cyear_3.yaml
@@ -42,6 +42,10 @@ product:
     - gqa:cep90
     - landsat:landsat_product_id
     - landsat:landsat_scene_id
+    - landsat:collection_category
+    - landsat:collection_number
+    - landsat:wrs_path
+    - landsat:wrs_row
 
   preview_image_ows_style:
     name: WOfS_frequency

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_fyear_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_fyear_3.yaml
@@ -42,6 +42,10 @@ product:
     - gqa:cep90
     - landsat:landsat_product_id
     - landsat:landsat_scene_id
+    - landsat:collection_category
+    - landsat:collection_number
+    - landsat:wrs_path
+    - landsat:wrs_row
 
   preview_image_ows_style:
     name: WOfS_frequency

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_myear_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_myear_3.yaml
@@ -42,6 +42,10 @@ product:
     - gqa:cep90
     - landsat:landsat_product_id
     - landsat:landsat_scene_id
+    - landsat:collection_category
+    - landsat:collection_number
+    - landsat:wrs_path
+    - landsat:wrs_row
 
   preview_image_ows_style:
     name: WOfS_frequency

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_nov_mar_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_nov_mar_3.yaml
@@ -42,6 +42,10 @@ product:
     - gqa:cep90
     - landsat:landsat_product_id
     - landsat:landsat_scene_id
+    - landsat:collection_category
+    - landsat:collection_number
+    - landsat:wrs_path
+    - landsat:wrs_row
 
   preview_image_ows_style:
     name: seasonal_WOfS_frequency


### PR DESCRIPTION
Add four fields from the landsat namespace to skip list. The following fileds will not in odc-stats output metadata files anymore.

```
    - landsat:collection_category
    - landsat:collection_number
    - landsat:wrs_path
    - landsat:wrs_row
```