### PR TITLE
Relocate provisional to subfolders for consistency with DEA Maps

### DIFF
--- a/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
@@ -278,6 +278,10 @@ For service status information, see https://status.dea.ga.gov.au""",
             ],
             "styling": {"default_style": "true_colour", "styles": styles_c3_ls_7},
         },
+        {
+            "include": "ows_refactored.baseline_satellite_data.landsat.ows_c3_cfg.combined_provisional_layer",
+            "type": "python",
+        },
     ],
 }
 

--- a/dev/services/wms/ows_refactored/baseline_satellite_data/ows_category_root_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/ows_category_root_cfg.py
@@ -7,15 +7,7 @@ category_layers = {
             "type": "python",
         },
         {
-            "include": "ows_refactored.baseline_satellite_data.landsat.ows_c3_cfg.combined_provisional_layer",
-            "type": "python",
-        },
-        {
             "include": "ows_refactored.baseline_satellite_data.sentinel2.ows_nrt_cfg.combined_layer",
-            "type": "python",
-        },
-        {
-            "include": "ows_refactored.baseline_satellite_data.sentinel2.ows_nrt_provisional_cfg.combined_layer",
             "type": "python",
         },
         {

--- a/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/ows_s2_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/ows_s2_cfg.py
@@ -11,6 +11,10 @@ category_layers = {
             "type": "python",
         },
         {
+            "include": "ows_refactored.baseline_satellite_data.sentinel2.ows_nrt_provisional_cfg.combined_layer",
+            "type": "python",
+        },
+        {
             "include": "ows_refactored.baseline_satellite_data.sentinel2.ows_nrt_provisional_cfg.s2b_layer",
             "type": "python",
         },


### PR DESCRIPTION
This PR moves the two provisional combined layers into the subfolders "DEA Surface Reflectance (Landsat)" and "DEA Surface Reflectance (Sentinel-2)" for consistency with Terria Cube and DEA Maps.

@pindge Please let me know if I have done particularly the Landsat one correctly!