### PR TITLE
add tasseled cap index percentile product definition

### DIFF
--- a/products/inland_water/c3_tc/ga_ls_tc_pc_cyear_3.yaml
+++ b/products/inland_water/c3_tc/ga_ls_tc_pc_cyear_3.yaml
@@ -1,0 +1,24 @@
+name: ga_ls_tc_pc_cyear_3
+description: Geoscience Australia Landsat Tasseled Cap Percentile Calendar Year Collection 3
+license: CC-BY-4.0
+metadata_type: eo3
+
+metadata: 
+  product:
+    name: ga_ls_tc_pc_cyear_3
+
+measurements:
+  - name: wet_pc_10
+    dtype: int16
+    units: 'percent'
+    nodata: -9999
+
+  - name: wet_pc_50
+    dtype: int16
+    units: 'percent'
+    nodata: -9999
+
+  - name: wet_pc_90
+    dtype: int16
+    units: 'percent'
+    nodata: -9999


### PR DESCRIPTION
Tasseled cap index percentile product definition, internal only for mangroves

- Currently it has only wetness, save expansion to later brightness and greenness if we decide to release it as a product 
- change band name `tcw_pc_xx`  of `C2` to `wet_pc_xx` so that we can have `green_pc_xx` or `bright_pc_xx`