### PR TITLE
Change wo family name to meet expected pattern

### DIFF
--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_apr_oct_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_apr_oct_3.yaml
@@ -3,7 +3,7 @@ product:
   name: ga_ls_wo_fq_apr_oct_3
   short_name: ga_ls_wo_fq_apr_oct_3
   version: 1.6.0
-  product_family: DEA Water Observations (WOfS)
+  product_family: wo
 
   # -- EO Dataset3 relative section --
   naming_conventions_values: dea_c3

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_cyear_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_cyear_3.yaml
@@ -3,7 +3,7 @@ product:
   name: ga_ls_wo_fq_cyear_3
   short_name: ga_ls_wo_fq_cyear_3
   version: 1.6.0
-  product_family: DEA Water Observations (WOfS)
+  product_family: wo
 
   # -- EO Dataset3 relative section --
   naming_conventions_values: dea_c3

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_fyear_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_fyear_3.yaml
@@ -3,7 +3,7 @@ product:
   name: ga_ls_wo_fq_fyear_3
   short_name: ga_ls_wo_fq_fyear_3
   version: 1.6.0
-  product_family: DEA Water Observations (WOfS)
+  product_family: wo
 
   # -- EO Dataset3 relative section --
   naming_conventions_values: dea_c3

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_myear_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_myear_3.yaml
@@ -3,7 +3,7 @@ product:
   name: ga_ls_wo_fq_myear_3
   short_name: ga_ls_wo_fq_myear_3
   version: 1.6.0
-  product_family: DEA Water Observations (WOfS)
+  product_family: wo
 
   # -- EO Dataset3 relative section --
   naming_conventions_values: dea_c3

--- a/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_nov_mar_3.yaml
+++ b/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_nov_mar_3.yaml
@@ -3,7 +3,7 @@ product:
   name: ga_ls_wo_fq_nov_mar_3
   short_name: ga_ls_wo_fq_nov_mar_3
   version: 1.6.0
-  product_family: DEA Water Observations (WOfS)
+  product_family: wo
 
   # -- EO Dataset3 relative section --
   naming_conventions_values: dea_c3


### PR DESCRIPTION
The previous value `DEA Water Observations (WOfS)` does not follow the common pattern: `an identifier (alphanumeric with underscores, typically lowercase`. Then reuse the `ga_ls_wo_3` family name value [wo](https://github.com/GeoscienceAustralia/dea-config/blob/master/prod/services/alchemist/ga_ls_wo_3/ga_ls_wo_3.alchemist.yaml#L43).