### PR TITLE
Add FC fyear product cfg

### DIFF
--- a/products/land_and_vegetation/fc/ga_ls_fc_pc_fyear_3.yaml
+++ b/products/land_and_vegetation/fc/ga_ls_fc_pc_fyear_3.yaml
@@ -1,0 +1,67 @@
+name: ga_ls_fc_pc_fyear_3
+description: Geoscience Australia Landsat Fractional Cover Percentile Financial Year Collection 3
+license: CC-BY-4.0
+metadata_type: eo3
+
+metadata: 
+  product:
+    name: ga_ls_fc_pc_fyear_3
+
+measurements:
+  - name: pv_pc_10
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: pv_pc_50
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: pv_pc_90
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: bs_pc_10
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: bs_pc_50
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: bs_pc_90
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: npv_pc_10
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: npv_pc_50
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: npv_pc_90
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: qa
+    dtype: uint8
+    units: '1'
+    nodata: 255
+    flags_definition:
+      qa:
+        bits: [0,1,2,3,4,5,6,7]
+        values:
+          0: insufficient observations wet
+          1: insufficient observations dry
+          2: sufficient observations
+        description: Quality Assurance


### PR DESCRIPTION
Add `Fractional Cover Percentile Financial Year` product definition config. 

This new product cfg only has different `name`, `metadata.product.name` and `description` values when compare with `Fractional Cover Percentile Calendar Year` [cfg](https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/products/land_and_vegetation/fc/ga_ls_fc_pc_cyear_3.yaml).