### PR TITLE
change s2 product back to c2 for wo config

### DIFF
--- a/dev/services/alchemist/s2_nrt_wo/s2_nrt_wo.alchemist.yaml
+++ b/dev/services/alchemist/s2_nrt_wo/s2_nrt_wo.alchemist.yaml
@@ -1,7 +1,7 @@
 specification:
   products:
-    - ga_s2bm_ard_provisional_3
-    - ga_s2am_ard_provisional_3
+    - s2a_nrt_granule
+    - s2b_nrt_granule
   measurements: ['nbart_blue', 'nbart_green', 'nbart_red', 'nbart_nir_1', 'nbart_swir_2', 'nbart_swir_3', 'fmask']
   measurement_renames:
     nbart_nir_1: nbart_nir


### PR DESCRIPTION
Change s2 nrt product back to s2c2, as assumption about updating nrt s2 wo from c2 (s2*_nrt_granule) to c3 (ga_s2*m_ard_provisional_3) was incorrect. Not just as easy as changing product name. 