### PR TITLE
Fix wo seaonal summary metadata type

### DIFF
--- a/products/inland_water/wofs/ga_ls_wo_fq_apr_oct_3.yaml
+++ b/products/inland_water/wofs/ga_ls_wo_fq_apr_oct_3.yaml
@@ -1,6 +1,6 @@
 name: ga_ls_wo_fq_apr_oct_3
 description: Geoscience Australia Landsat Water Observations Frequency April to October Collection 3
-metadata_type: eo
+metadata_type: eo3
 
 metadata:
   properties:

--- a/products/inland_water/wofs/ga_ls_wo_fq_nov_mar_3.yaml
+++ b/products/inland_water/wofs/ga_ls_wo_fq_nov_mar_3.yaml
@@ -1,6 +1,6 @@
 name: ga_ls_wo_fq_nov_mar_3
 description: Geoscience Australia Landsat Water Observations Frequency November to March Collection 3
-metadata_type: eo
+metadata_type: eo3
 
 metadata:
   properties:


### PR DESCRIPTION
When we add the WO seasonal summary, eventually I modify the existing C2 ones. Then the metadata_type still referece to the C2 style.

In this PR, we update the two WO seasonal summary metadata_type to C3 style (e.g. C3 cyear one https://github.com/GeoscienceAustralia/dea-config/blob/master/products/inland_water/wofs/ga_ls_wo_fq_cyear_3.yaml#L3.)