### PR TITLE
Add sensible WCS resource limits.

### DIFF
--- a/dev/services/wms/ows_refactored/ows_reslim_cfg.py
+++ b/dev/services/wms/ows_refactored/ows_reslim_cfg.py
@@ -70,3 +70,4 @@ reslim_wms_min_zoom_500_max_datasets = {
     },
     "wcs": common_wcs_limits,
 }
+

--- a/dev/services/wms/ows_refactored/ows_reslim_cfg.py
+++ b/dev/services/wms/ows_refactored/ows_reslim_cfg.py
@@ -1,4 +1,5 @@
-# Reusable Chunks 1. Resource limit configurations
+# dataset cache rules - enable caching hints to optimise effectiveness of 
+#                       external caches (e.g Cloudfront)
 
 dataset_cache_rules = [
     {
@@ -11,6 +12,15 @@ dataset_cache_rules = [
     },
 ]
 
+common_wcs_limits = {
+    # Maximum size in bytes of uncompressed image that can be
+    # returned.
+    "max_image_size": 800_000_000,
+    # Maximum number of datasets that can be accessed in a
+    # single query
+    "max_datasets": 30,   # defaults to no limit
+}
+
 reslim_wms_min_zoom_35 = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
@@ -18,9 +28,7 @@ reslim_wms_min_zoom_35 = {
         # "max_datasets": 16, # Defaults to no dataset limit
         "dataset_cache_rules": dataset_cache_rules
     },
-    "wcs": {
-        # "max_datasets": 16, # Defaults to no dataset limit
-    },
+    "wcs": common_wcs_limits,
 }
 
 reslim_wms_min_zoom_15 = {
@@ -30,9 +38,7 @@ reslim_wms_min_zoom_15 = {
         # "max_datasets": 16, # Defaults to no dataset limit
         "dataset_cache_rules": dataset_cache_rules,
     },
-    "wcs": {
-        # "max_datasets": 16, # Defaults to no dataset limit
-    },
+    "wcs": common_wcs_limits,
 }
 reslim_wms_min_zoom_15_cache_rules = reslim_wms_min_zoom_15
 
@@ -43,9 +49,7 @@ reslim_wms_min_zoom_10 = {
         # "max_datasets": 16, # Defaults to no dataset limit
         "dataset_cache_rules": dataset_cache_rules,
     },
-    "wcs": {
-        # "max_datasets": 16, # Defaults to no dataset limit
-    },
+    "wcs": common_wcs_limits,
 }
 
 reslim_wms_min_zoom_15 = {
@@ -55,9 +59,7 @@ reslim_wms_min_zoom_15 = {
         # "max_datasets": 16, # Defaults to no dataset limit
         "dataset_cache_rules": dataset_cache_rules
     },
-    "wcs": {
-        # "max_datasets": 16, # Defaults to no dataset limit
-    },
+    "wcs": common_wcs_limits,
 }
 
 reslim_wms_min_zoom_500_max_datasets = {
@@ -66,7 +68,5 @@ reslim_wms_min_zoom_500_max_datasets = {
         "min_zoom_factor": 500.0,
         "max_datasets": 6,
     },
-    "wcs": {
-        "max_datasets": 16,
-    },
+    "wcs": common_wcs_limits,
 }

--- a/dev/services/wms/ows_refactored/ows_reslim_cfg.py
+++ b/dev/services/wms/ows_refactored/ows_reslim_cfg.py
@@ -1,4 +1,4 @@
-# dataset cache rules - enable caching hints to optimise effectiveness of 
+# dataset cache rules - enable caching hints to optimise effectiveness of
 #                       external caches (e.g Cloudfront)
 
 dataset_cache_rules = [
@@ -70,4 +70,3 @@ reslim_wms_min_zoom_500_max_datasets = {
     },
     "wcs": common_wcs_limits,
 }
-


### PR DESCRIPTION
WCS requests were previously unrestricted, which means that a large WCS request would time out and eventually crash the pod instead of failing immediately with a useful error message.

The following restrictions now apply to all WCS requests:

1) Limit on the size of the uncompressed data to 800Mb.
2) Limit on the total number of dataset file accessed to 30.