### PR TITLE
FC C3 masking overhaul in dev.

### DIFF
--- a/dev/services/wms/inventory.json
+++ b/dev/services/wms/inventory.json
@@ -653,12 +653,16 @@
             "product": [
                 "ga_ls_fc_3"
             ],
-            "styles_count": 4,
+            "styles_count": 8,
             "styles_list": [
                 "fc_rgb",
                 "bare_ground_c3",
                 "green_veg_c3",
-                "non_green_veg_c3"
+                "non_green_veg_c3",
+                "fc_rgb_unmasked",
+                "bare_ground_c3_unmasked",
+                "green_veg_c3_unmasked",
+                "non_green_veg_c3_unmasked"
             ]
         },
         {

--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/ows_c3_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/ows_c3_fc_cfg.py
@@ -1,9 +1,8 @@
 from ows_refactored.land_and_vegetation.fc.band_fc_cfg import bands_fc_3
 from ows_refactored.land_and_vegetation.fc.style_fc_cfg import (
-                    style_fc_bs_c3, style_fc_bs_c3_unmasked, 
-                    style_fc_c3_rgb, style_fc_c3_rgb_unmasked, 
-                    style_fc_gv_c3, style_fc_gv_c3_unmasked, 
-                    style_fc_ngv_c3_unmasked)
+    style_fc_bs_c3, style_fc_bs_c3_unmasked, style_fc_c3_rgb,
+    style_fc_c3_rgb_unmasked, style_fc_gv_c3, style_fc_gv_c3_unmasked,
+    style_fc_ngv_c3, style_fc_ngv_c3_unmasked)
 from ows_refactored.ows_reslim_cfg import reslim_wms_min_zoom_35
 
 layer = {
@@ -58,7 +57,6 @@ For service status information, see https://status.dea.ga.gov.au
             style_fc_bs_c3,
             style_fc_gv_c3,
             style_fc_ngv_c3,
-
             style_fc_c3_rgb_unmasked,
             style_fc_bs_c3_unmasked,
             style_fc_gv_c3_unmasked,

--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/ows_c3_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/ows_c3_fc_cfg.py
@@ -1,6 +1,9 @@
 from ows_refactored.land_and_vegetation.fc.band_fc_cfg import bands_fc_3
 from ows_refactored.land_and_vegetation.fc.style_fc_cfg import (
-    style_fc_bs_c3, style_fc_c3_rgb, style_fc_gv_c3, style_fc_ngv_c3)
+                    style_fc_bs_c3, style_fc_bs_c3_unmasked, 
+                    style_fc_c3_rgb, style_fc_c3_rgb_unmasked, 
+                    style_fc_gv_c3, style_fc_gv_c3_unmasked, 
+                    style_fc_ngv_c3_unmasked)
 from ows_refactored.ows_reslim_cfg import reslim_wms_min_zoom_35
 
 layer = {
@@ -55,6 +58,11 @@ For service status information, see https://status.dea.ga.gov.au
             style_fc_bs_c3,
             style_fc_gv_c3,
             style_fc_ngv_c3,
+
+            style_fc_c3_rgb_unmasked,
+            style_fc_bs_c3_unmasked,
+            style_fc_gv_c3_unmasked,
+            style_fc_ngv_c3_unmasked,
         ],
     },
 }

--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -8,7 +8,7 @@ c3_fc_pq_mask = [
         # pq_masks:band now takes the actual ODC band name, not the identifier.
         "band": "water",
         "flags": {
-            "water_observed": False
+            "water_observed": False,
             "terrain_shadow": False,
             "low_solar_angle": False,
             "high_slope": False,

--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -92,7 +92,7 @@ style_fc_gv_c3 = {
     "pq_masks": c3_fc_pq_mask,
 }
 
-style_fc_bs_c3_umasked = {
+style_fc_bs_c3_unmasked = {
     "name": "bare_ground_c3_umasked",
     "title": "Bare Ground Unmasked (Warning: includes invalid data)",
     "abstract": "Bare Soil",
@@ -138,7 +138,7 @@ style_fc_bs_c3 = {
     "pq_masks": c3_fc_pq_mask,
 }
 
-style_fc_ngv_c3_umasked = {
+style_fc_ngv_c3_unmasked = {
     "name": "non_green_veg_c3_unmasked",
     "title": "Non-Green Vegetation Unmasked (Warning: includes invalid data)",
     "abstract": "Non Green Vegetation",
@@ -157,8 +157,8 @@ style_fc_ngv_c3_umasked = {
             "color": "#ffffd4",
         },
         {
-            "value": 25, 
-            "color": "#fed98e", 
+            "value": 25,
+            "color": "#fed98e",
         },
         {
             "value": 50,

--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -93,7 +93,7 @@ style_fc_gv_c3 = {
 }
 
 style_fc_bs_c3_unmasked = {
-    "name": "bare_ground_c3_umasked",
+    "name": "bare_ground_c3_unmasked",
     "title": "Bare Ground Unmasked (Warning: includes invalid data)",
     "abstract": "Bare Soil",
     "index_function": {

--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -7,16 +7,14 @@ c3_fc_pq_mask = [
     {
         # pq_masks:band now takes the actual ODC band name, not the identifier.
         "band": "water",
-        "flags": {"dry": True},
-    },
-    {
-        "band": "water",
         "flags": {
+            "water_observed": False
             "terrain_shadow": False,
             "low_solar_angle": False,
             "high_slope": False,
             "cloud_shadow": False,
             "cloud": False,
+            "nodata": False,
         },
     },
     {
@@ -26,9 +24,9 @@ c3_fc_pq_mask = [
     },
 ]
 
-style_fc_c3_rgb = {
-    "name": "fc_rgb",
-    "title": "Three-band Fractional Cover",
+style_fc_c3_unmasked = {
+    "name": "fc_rgb_unmasked",
+    "title": "Three-band Fractional Cover Unmasked (Warning: includes invalid data)",
     "abstract": "Fractional cover medians - red is bare soil, green is green vegetation and blue is non-green vegetation",
     "components": {
         "red": {"bs": 1.0},
@@ -36,16 +34,22 @@ style_fc_c3_rgb = {
         "blue": {"npv": 1.0},
     },
     "scale_range": [0.0, 100.0],
-    "pq_masks": c3_fc_pq_mask,
     "legend": {
         "show_legend": True,
         "url": "https://data.dea.ga.gov.au/fractional-cover/FC_legend.png",
     },
 }
 
-style_fc_gv_c3 = {
-    "name": "green_veg_c3",
-    "title": "Green Vegetation",
+style_fc_c3_masked = {
+    "inherits": style_fc_c3_unmasked,
+    "name": "fc_rgb",
+    "title": "Three-band Fractional Cover",
+    "pq_masks": c3_fc_pq_mask,
+}
+
+style_fc_gv_c3_unmasked = {
+    "name": "green_veg_c3_unmasked",
+    "title": "Green Vegetation Unmasked (Warning: includes invalid data)",
     "abstract": "Green Vegetation",
     "index_function": {
         "function": "datacube_ows.band_utils.single_band",
@@ -78,13 +82,19 @@ style_fc_gv_c3 = {
             "color": "#006837",
         },
     ],
-    "pq_masks": c3_fc_pq_mask,
     "legend": legend_idx_0_100_pixel_fc_25ticks,
 }
 
-style_fc_bs_c3 = {
-    "name": "bare_ground_c3",
-    "title": "Bare Ground",
+style_fc_gv_c3 = {
+    "inherits": style_fc_gv_c3_unmasked,
+    "name": "green_veg_c3",
+    "title": "Green Vegetation",
+    "pq_masks": c3_fc_pq_mask,
+}
+
+style_fc_bs_c3_umasked = {
+    "name": "bare_ground_c3_umasked",
+    "title": "Bare Ground Unmasked (Warning: includes invalid data)",
     "abstract": "Bare Soil",
     "index_function": {
         "function": "datacube_ows.band_utils.single_band",
@@ -117,14 +127,20 @@ style_fc_bs_c3 = {
             "color": "#7a0177",
         },
     ],
-    "pq_masks": c3_fc_pq_mask,
     # Emulates what we had previously
     "legend": legend_idx_0_100_pixel_fc_bs_25ticks,
 }
 
-style_fc_ngv_c3 = {
-    "name": "non_green_veg_c3",
-    "title": "Non-Green vegetation",
+style_fc_bs_c3 = {
+    "inherits": style_fc_bs_c3_unmasked,
+    "name": "bare_ground_c3",
+    "title": "Bare Ground",
+    "pq_masks": c3_fc_pq_mask,
+}
+
+style_fc_ngv_c3_umasked = {
+    "name": "non_green_veg_c3_unmasked",
+    "title": "Non-Green Vegetation Unmasked (Warning: includes invalid data)",
     "abstract": "Non Green Vegetation",
     "index_function": {
         "function": "datacube_ows.band_utils.single_band",
@@ -140,7 +156,10 @@ style_fc_ngv_c3 = {
             "value": 0,
             "color": "#ffffd4",
         },
-        {"value": 25, "color": "#fed98e", "legend": {}},
+        {
+            "value": 25, 
+            "color": "#fed98e", 
+        },
         {
             "value": 50,
             "color": "#fe9929",
@@ -156,6 +175,12 @@ style_fc_ngv_c3 = {
     ],
     # Emulates what we had previously
     "legend": legend_idx_0_100_pixel_fc_ngv_25ticks,
+}
+
+style_fc_ngv_c3 = {
+    "inherits": style_fc_ngv_c3_unmasked,
+    "name": "non_green_veg_c3",
+    "title": "Non-Green vegetation",
     "pq_masks": c3_fc_pq_mask,
 }
 

--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -24,7 +24,7 @@ c3_fc_pq_mask = [
     },
 ]
 
-style_fc_c3_unmasked = {
+style_fc_c3_rgb_unmasked = {
     "name": "fc_rgb_unmasked",
     "title": "Three-band Fractional Cover Unmasked (Warning: includes invalid data)",
     "abstract": "Fractional cover medians - red is bare soil, green is green vegetation and blue is non-green vegetation",
@@ -40,8 +40,8 @@ style_fc_c3_unmasked = {
     },
 }
 
-style_fc_c3_masked = {
-    "inherits": style_fc_c3_unmasked,
+style_fc_c3_rgb = {
+    "inherits": style_fc_c3_rgb_unmasked,
     "name": "fc_rgb",
     "title": "Three-band Fractional Cover",
     "pq_masks": c3_fc_pq_mask,


### PR DESCRIPTION
Fix masked styles to mask out all data where no QA is available from WOFS.

Added unmasked styles for review and assessment - may be removed, or may be made selectively available in some Terria instances.

(for Collection 3 Landsat FC in dev only.)

Requires code changes from https://github.com/opendatacube/datacube-ows/pull/772 to work correctly.