### PR TITLE
Add dev-only unmasked styles to FC C3

### DIFF
--- a/dev/services/wms/inventory.json
+++ b/dev/services/wms/inventory.json
@@ -670,12 +670,16 @@
             "product": [
                 "ga_ls_fc_c2_3"
             ],
-            "styles_count": 4,
+            "styles_count": 8,
             "styles_list": [
                 "fc_rgb",
                 "bare_ground_c3",
                 "green_veg_c3",
-                "non_green_veg_c3"
+                "non_green_veg_c3",
+                "fc_rgb_unmasked",
+                "bare_ground_c3_unmasked",
+                "green_veg_c3_unmasked",
+                "non_green_veg_c3_unmasked"
             ]
         },
         {

--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/ows_c3_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/ows_c3_fc_cfg.py
@@ -1,8 +1,6 @@
 from ows_refactored.land_and_vegetation.fc.band_fc_cfg import bands_fc_3
 from ows_refactored.land_and_vegetation.fc.style_fc_cfg import (
-    style_fc_bs_c3, style_fc_bs_c3_unmasked, style_fc_c3_rgb,
-    style_fc_c3_rgb_unmasked, style_fc_gv_c3, style_fc_gv_c3_unmasked,
-    style_fc_ngv_c3, style_fc_ngv_c3_unmasked)
+    styles_fc_c3_masked, styles_fc_c3_unmasked)
 from ows_refactored.ows_reslim_cfg import reslim_wms_min_zoom_35
 
 layer = {
@@ -52,16 +50,10 @@ For service status information, see https://status.dea.ga.gov.au
     ],
     "styling": {
         "default_style": "fc_rgb",
-        "styles": [
-            style_fc_c3_rgb,
-            style_fc_bs_c3,
-            style_fc_gv_c3,
-            style_fc_ngv_c3,
-            style_fc_c3_rgb_unmasked,
-            style_fc_bs_c3_unmasked,
-            style_fc_gv_c3_unmasked,
-            style_fc_ngv_c3_unmasked,
-        ],
+        # FOR DEV ONLY - DO NOT PROMOTE UNMASKED STYLES TO PROD
+        "styles": styles_fc_c3_masked + styles_fc_c3_unmasked
+        # FOR PROD ONLY - DO NOT REMOVE UNMASKED STYLES FROM DEV
+        # "styles": styles_fc_c3_masked
     },
 }
 
@@ -112,11 +104,9 @@ For service status information, see https://status.dea.ga.gov.au
     ],
     "styling": {
         "default_style": "fc_rgb",
-        "styles": [
-            style_fc_c3_rgb,
-            style_fc_bs_c3,
-            style_fc_gv_c3,
-            style_fc_ngv_c3,
-        ],
+        # FOR DEV ONLY - DO NOT PROMOTE UNMASKED STYLES TO PROD
+        "styles": styles_fc_c3_masked + styles_fc_c3_unmasked
+        # FOR PROD ONLY - DO NOT REMOVE UNMASKED STYLES FROM DEV
+        # "styles": styles_fc_c3_masked
     },
 }

--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -184,6 +184,16 @@ style_fc_ngv_c3 = {
     "pq_masks": c3_fc_pq_mask,
 }
 
+
+styles_fc_c3_masked = [
+    style_fc_c3_rgb, 
+    style_fc_bs_c3, style_fc_gv_c3, style_fc_ngv_c3
+]
+styles_fc_c3_unmasked = [
+    style_fc_c3_rgb_unmasked, 
+    style_fc_bs_c3_unmasked, style_fc_gv_c3_unmasked, style_fc_ngv_c3_unmasked
+]
+
 style_fc_simple_rgb = {
     "name": "simple_rgb",
     "title": "Simple RGB",

--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -186,11 +186,11 @@ style_fc_ngv_c3 = {
 
 
 styles_fc_c3_masked = [
-    style_fc_c3_rgb, 
+    style_fc_c3_rgb,
     style_fc_bs_c3, style_fc_gv_c3, style_fc_ngv_c3
 ]
 styles_fc_c3_unmasked = [
-    style_fc_c3_rgb_unmasked, 
+    style_fc_c3_rgb_unmasked,
     style_fc_bs_c3_unmasked, style_fc_gv_c3_unmasked, style_fc_ngv_c3_unmasked
 ]
 


### PR DESCRIPTION
Unmasked styles are

*    useful for internal debugging of situations where there is a difference in extent between FC and WOFS or other issues with masking; and
 *   could potentially be of interest to some external power-users; but
*    potentially for confusing amongst non-expert users.

We are therefore adding them permanently to dev, and leaving them permanently out of prod.

This applies the rest of this policy to FC C3 and is exemplar for refactoring all[1] masked styles going forward.

[1] If the only masking is sea masking, it's not really worth it - this is why I haven't done e.g. the annual and seasonal wofs layers in this PR.