### PR TITLE
Fix LS8 Fractional Cover Alchemist Configuration

### DIFF
--- a/prod/services/alchemist/ga_ls_fc_3/ga_ls_fc_3.alchemist.yaml
+++ b/prod/services/alchemist/ga_ls_fc_3/ga_ls_fc_3.alchemist.yaml
@@ -38,6 +38,16 @@ specification:
         swir2:
           - -32.7
           - 1.02551
+      fc_coefficients:
+        bs:
+          - 2.45
+          - 0.9499
+        pv:
+          - 2.77
+          - 0.9481
+        npv:
+          - -0.73
+          - 0.9578
 
 output:
   location: s3://dea-public-data/derivative/
@@ -46,7 +56,7 @@ output:
   preview_image:
     red: bs
     green: pv
-    blue: pv
+    blue: npv
   explorer_url: https://explorer.dea.ga.gov.au
   write_data_settings:
     overview_resampling: average


### PR DESCRIPTION
- Add an extra group of coefficients on ls8 
- fix small error on preview thumbnail

Open to the change of coefficients name.

See https://github.com/GeoscienceAustralia/fc/pull/48 for more context on the new set of coefficients.