### PR TITLE
Make Landcover Extents Prettier in Explorer

### DIFF
--- a/products/land_and_vegetation/lccs/lc_ls_c2.odc-product.yaml
+++ b/products/land_and_vegetation/lccs/lc_ls_c2.odc-product.yaml
@@ -63,4 +63,12 @@ measurements:
     dtype: int8
     nodata: 0
     units: '1'
+storage:
+  crs: EPSG:3577
+  tile_size:
+    x: 100000.0
+    y: 100000.0
+  resolution:
+    x: 25
+    y: -25
 


### PR DESCRIPTION
Adding the expected gridding into the Landcover Product definition should make it look prettier in Explorer.

Please confirm that Landcover uses the same tiling configuration as the Collection 2 Albers products.

![image](https://user-images.githubusercontent.com/108979/145318506-0f80f618-f6b7-4daa-b768-ce9cebbe09e4.png)


![image](https://user-images.githubusercontent.com/108979/145318459-ae5f0e0e-e82a-4d72-9be1-3a42a5ca9447.png)
