### PR TITLE
Switch most dev wms resource limits to adjusted zoom level

### DIFF
--- a/dev/services/wms/ows_refactored/ows_reslim_cfg.py
+++ b/dev/services/wms/ows_refactored/ows_reslim_cfg.py
@@ -25,7 +25,7 @@ reslim_wms_min_zoom_35 = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
         "min_zoom_level": 6.9,
-# "min_zoom_factor": 35.0,
+        # "min_zoom_factor": 35.0,
         # "max_datasets": 16, # Defaults to no dataset limit
         "dataset_cache_rules": dataset_cache_rules
     },
@@ -36,7 +36,7 @@ reslim_wms_min_zoom_15 = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
         "min_zoom_level": 6.9,
-#         "min_zoom_factor": 15.0,
+        # "min_zoom_factor": 15.0,
         # "max_datasets": 16, # Defaults to no dataset limit
         "dataset_cache_rules": dataset_cache_rules,
     },
@@ -48,7 +48,7 @@ reslim_wms_min_zoom_10 = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
         "min_zoom_level": 6.9,
-#         "min_zoom_factor": 10.0,
+        # "min_zoom_factor": 10.0,
         # "max_datasets": 16, # Defaults to no dataset limit
         "dataset_cache_rules": dataset_cache_rules,
     },

--- a/dev/services/wms/ows_refactored/ows_reslim_cfg.py
+++ b/dev/services/wms/ows_refactored/ows_reslim_cfg.py
@@ -24,7 +24,8 @@ common_wcs_limits = {
 reslim_wms_min_zoom_35 = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
-        "min_zoom_factor": 35.0,
+        "min_zoom_level": 6.9,
+# "min_zoom_factor": 35.0,
         # "max_datasets": 16, # Defaults to no dataset limit
         "dataset_cache_rules": dataset_cache_rules
     },
@@ -34,7 +35,8 @@ reslim_wms_min_zoom_35 = {
 reslim_wms_min_zoom_15 = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
-        "min_zoom_factor": 15.0,
+        "min_zoom_level": 6.9,
+#         "min_zoom_factor": 15.0,
         # "max_datasets": 16, # Defaults to no dataset limit
         "dataset_cache_rules": dataset_cache_rules,
     },
@@ -45,7 +47,8 @@ reslim_wms_min_zoom_15_cache_rules = reslim_wms_min_zoom_15
 reslim_wms_min_zoom_10 = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
-        "min_zoom_factor": 10.0,
+        "min_zoom_level": 6.9,
+#         "min_zoom_factor": 10.0,
         # "max_datasets": 16, # Defaults to no dataset limit
         "dataset_cache_rules": dataset_cache_rules,
     },
@@ -55,7 +58,7 @@ reslim_wms_min_zoom_10 = {
 reslim_wms_min_zoom_lvl_7 = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
-        "min_zoom_factor": 6.9,
+        "min_zoom_level": 6.9,
         # "max_datasets": 16, # Defaults to no dataset limit
         "dataset_cache_rules": dataset_cache_rules
     },


### PR DESCRIPTION
1. S2 NRT was set to min_zoom_factor of 6.9, which is insane.  The intention was clearly min_zoom_level of 6.9, which I think is reasonable.
2. min_zoom_level has a "smart" implementation to automatically adjust for factors like native resolution, number (and size) of bands, etc.  So a single min_zoom_level value should suffice for most (if not all) layers.  I've therefore moved almost everything over to share a min_zoom_level of 6.9.
3. I've NOT included the HAP prototype layer because it really is a special case.
4. This is dev only.  I'll do some tests and profiling after this is deployed, and if I'm happy, I'll simplify by reducing the number of (now identical) resource limit definitions, then promote to prod.