### PR TITLE
Resource limit tuning for MSTP (dev only for now)

### DIFF
--- a/dev/services/wms/ows_refactored/others/ows_mstp_cfg.py
+++ b/dev/services/wms/ows_refactored/others/ows_mstp_cfg.py
@@ -1,4 +1,4 @@
-from ows_refactored.ows_reslim_cfg import reslim_standard
+from ows_refactored.ows_reslim_cfg import reslim_for_mstp
 
 bands_multi_topog = {
     "regional": [],
@@ -49,7 +49,7 @@ Geomorphology 245, 51–61.
 For service status information, see https://status.dea.ga.gov.au""",
             "product_name": "multi_scale_topographic_position",
             "bands": bands_multi_topog,
-            "resource_limits": reslim_standard,
+            "resource_limits": reslim_for_mstp,
             "native_crs": "EPSG:4326",
             "native_resolution": [
                 0.000833333333347,

--- a/dev/services/wms/ows_refactored/ows_reslim_cfg.py
+++ b/dev/services/wms/ows_refactored/ows_reslim_cfg.py
@@ -48,6 +48,15 @@ reslim_for_lccs = {
     "wcs": common_wcs_limits,
 }
 
+reslim_for_mstp = {
+    "wms": {
+        "zoomed_out_fill_colour": [150, 180, 200, 160],
+        "min_zoom_level": 8.1,
+        "dataset_cache_rules": dataset_cache_rules,
+    },
+    "wcs": common_wcs_limits,
+}
+
 reslim_wms_max_datasets_only = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],


### PR DESCRIPTION
Standard resource limit doesn't work well.  Looks like MSTP is divvied up into files (datasets) using standard grid boundaries, despite being much lower resolution.  As a result the zoom-level-adjustment calculation doesn't scale right.