### PR TITLE
Fix Collection 3 Fractional Cover

### DIFF
--- a/prod/services/alchemist/ga_ls_fc_3/ga_ls_fc_3.alchemist.yaml
+++ b/prod/services/alchemist/ga_ls_fc_3/ga_ls_fc_3.alchemist.yaml
@@ -38,16 +38,20 @@ specification:
         swir2:
           - -32.7
           - 1.02551
-      fc_coefficients:
-        bs:
-          - 2.45
-          - 0.9499
-        pv:
-          - 2.77
-          - 0.9481
-        npv:
-          - -0.73
-          - 0.9578
+      # Don't include fc_coefficients yet, since the updated FC code which uses
+      # it hasn't been merged or released yet.
+      #
+      # See https://github.com/GeoscienceAustralia/fc/pull/48/files
+      # fc_coefficients:
+      #   bs:
+      #     - 2.45
+      #     - 0.9499
+      #   pv:
+      #     - 2.77
+      #     - 0.9481
+      #   npv:
+      #     - -0.73
+      #     - 0.9578
 
 output:
   location: s3://dea-public-data/derivative/


### PR DESCRIPTION
We whoopsed in December by merging a configuration change to Fractional
Cover which performs corrections on the output values of Landsat
8 FC. The whoops is because the code hasn't yet been released yet, and
so LS8 FC has been failing since then!