### PR TITLE
Fix zoom_factor/zoom_level typo in reslims.

### DIFF
--- a/prod/services/wms/ows_refactored/ows_reslim_cfg.py
+++ b/prod/services/wms/ows_refactored/ows_reslim_cfg.py
@@ -33,7 +33,7 @@ reslim_standard = {
 reslim_for_sentinel2 = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
-        "min_zoom_factor": 5.9,
+        "min_zoom_level": 5.9,
         "dataset_cache_rules": dataset_cache_rules,
     },
     "wcs": common_wcs_limits,


### PR DESCRIPTION
The resource_limit in prod for Sentinel-2 products was using "min_zoom_factor" instead of "min_zoom_level" resulting in ridiculously expensive queries being attempted, with timeouts and crashes resulting.

This should fix.