### PR TITLE
add tab detector for terria lint

### DIFF
--- a/.github/workflows/terria_linting.yaml
+++ b/.github/workflows/terria_linting.yaml
@@ -25,6 +25,13 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v1
 
+    - name: Run tab detector
+      run: |
+        if grep -Pn "\t" dev/terria/*.json; then
+            echo 'Please replace tab with white spaces as per the lines indicated'
+            exit 1
+        fi
+
     - name: Run Json Linter
       run: |
         npm install jsonlint -g

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -1074,12 +1074,12 @@
                                             "disclaimer": "This graph shows the wet surface area of waterbodies as estimated from satellites. It does not show depth, volume, purpose of the waterbody, nor the source of the water. <br> For more detailed information see https://www.dea.ga.gov.au/products/dea-waterbodies."
                                         }
                                     },
-				    "legends": [
+                                    "legends": [
                                         {
                                             "url": "https://dea-public-data.s3.ap-southeast-2.amazonaws.com/derivative/dea_waterbodies/waterbodies_legend_full.png",
-					    "imageScaling": 0.5
+                                            "imageScaling": 0.5
                                         }
-				    ],
+                                    ],
                                     "id": "AS145s"
                                 },
                                 {
@@ -1094,12 +1094,12 @@
                                             "disclaimer": "This graph shows the wet surface area of waterbodies as estimated from satellites. It does not show depth, volume, purpose of the waterbody, nor the source of the water. <br> For more detailed information see https://www.dea.ga.gov.au/products/dea-waterbodies."
                                         }
                                     },
-				    "legends": [
+                                    "legends": [
                                         {
                                             "url": "https://dea-public-data.s3.ap-southeast-2.amazonaws.com/derivative/dea_waterbodies/waterbodies_legend_full.png",
-					    "imageScaling": 0.5
+                                            "imageScaling": 0.5
                                         }
-				    ],
+                                    ],
                                     "id": "AS145t"
                                 }
                             ]


### PR DESCRIPTION
closes #1072 

behaviours

```
dev/terria/terria-cube-v[8]json:1077:				    "legends": [
dev/terria/terria-cube-v8.json:1080:					    "imageScaling": 0.5
dev/terria/terria-cube-v8.json:1082:				    ],
dev/terria/terria-cube-v8.json:10[9]7:				    "legends": [
dev/terria/terria-cube-v8.json:1[10]0:					    "imageScaling": 0.5
dev/terria/terria-cube-v8.json:[11]02:				    ],
Please replace tab with white spaces as per the lines indicated
```