### PR TITLE
Add apply_eodatasets3 flag to LS8 Geomedian

### DIFF
--- a/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml
+++ b/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml
@@ -72,3 +72,4 @@ s3_acl: public-read
 # Generic product attributes
 cog_opts:
   zlevel: 9
+apply_eodatasets3: True


### PR DESCRIPTION
Update LS8 Geomedian config to add `apply_eodatasets3` flag to match the LS7 config:
https://github.com/GeoscienceAustralia/dea-config/blob/95a2f7ea4c5f380234c752e828492987edc8a544/dev/services/odc-stats/geomedian/ga_ls7e_nbart_gm_cyear_3.yaml#L75