### PR TITLE
Naming convention updates to Terria and OWS catalogues

### DIFF
--- a/dev/services/wms/ows_refactored/inland_water/wofs/annual/ows_wofs_annual_cfg.py
+++ b/dev/services/wms/ows_refactored/inland_water/wofs/annual/ows_wofs_annual_cfg.py
@@ -6,7 +6,7 @@ from ows_refactored.inland_water.wofs.styles_wo_cfg import (
 from ows_refactored.ows_reslim_cfg import reslim_standard
 
 c3_statistics_layer = {
-    "title": "Annual Water Observation Statistics - Calendar Year (Landsat)",
+    "title": "DEA Water Observations Calendar Year (Landsat)",
     "name": "ga_ls_wo_fq_cyear_3",
     "abstract": """**Geoscience Australia Water Observations, Annual Frequency Statistics, Calendar Year (Landsat, Collection 3, 30 m, WO-STATS-ANNUAL, 3.1.6).**
 

--- a/dev/services/wms/ows_refactored/inland_water/wofs/multiyear/ows_wofs_summary_cfg.py
+++ b/dev/services/wms/ows_refactored/inland_water/wofs/multiyear/ows_wofs_summary_cfg.py
@@ -5,7 +5,7 @@ from ows_refactored.inland_water.wofs.styles_wo_cfg import (
 from ows_refactored.ows_reslim_cfg import reslim_standard
 
 c3_wofs_layer = {
-    "title": "Multi Year Water Observation Statistics (Landsat)",
+    "title": "DEA Water Observations Multi Year (Landsat)",
     "name": "ga_ls_wo_fq_myear_3",
     "abstract": """**Geoscience Australia Water Observations, Multi Year Frequency Statistics, 1986 to near present (Landsat, Collection 3, 30 m, WO-STATS, Frequency, 3.1.6).**
 

--- a/dev/services/wms/ows_refactored/inland_water/wofs/seasonal/ows_wofs_apr_oct_cfg.py
+++ b/dev/services/wms/ows_refactored/inland_water/wofs/seasonal/ows_wofs_apr_oct_cfg.py
@@ -6,7 +6,7 @@ from ows_refactored.inland_water.wofs.styles_wo_cfg import (
 from ows_refactored.ows_reslim_cfg import reslim_standard
 
 c3_statistics_layer = {
-    "title": "Seasonal Water Observation Statistics - April to October (Landsat)",
+    "title": "DEA Water Observations April to October (Landsat)",
     "name": "ga_ls_wo_fq_apr_oct_3",
     "abstract": """**Geoscience Australia Water Observations, Seasonal Frequency Statistics, April to October (Landsat, Collection 3, 30 m, WO-STATS-APR-OCT, 3.1.6).**
 

--- a/dev/services/wms/ows_refactored/inland_water/wofs/seasonal/ows_wofs_nov_mar_cfg.py
+++ b/dev/services/wms/ows_refactored/inland_water/wofs/seasonal/ows_wofs_nov_mar_cfg.py
@@ -6,7 +6,7 @@ from ows_refactored.inland_water.wofs.styles_wo_cfg import (
 from ows_refactored.ows_reslim_cfg import reslim_standard
 
 c3_statistics_layer = {
-    "title": "Seasonal Water Observation Statistics - November to March (Landsat)",
+    "title": "DEA Water Observations November to March (Landsat)",
     "name": "ga_ls_wo_fq_nov_mar_3",
     "abstract": """**Geoscience Australia Water Observations, Seasonal Frequency Statistics, November to March (Landsat, Collection 3, 30 m, WO-STATS-NOV-MAR, 3.1.6).**
 

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal/ows_extents_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal/ows_extents_cfg.py
@@ -149,7 +149,7 @@ style_item_confidence = {
 }
 
 item_v2_00_layer = {
-    "title": "DEA Intertidal Extents (ITEM)",
+    "title": "DEA Intertidal Extents (Landsat)",
     "name": "ITEM_V2.0.0",
     "abstract": """Intertidal Extents Model 25m 2.0.0 (Extents)
 

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal/ows_national_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal/ows_national_cfg.py
@@ -80,7 +80,7 @@ style_nidem = {
 
 
 layer = {
-    "title": "DEA Intertidal Elevation (NIDEM)",
+    "title": "DEA Intertidal Elevation (Landsat)",
     "name": "NIDEM",
     "abstract": """National Intertidal Digital Elevation Model 25m 1.0.0
 

--- a/dev/terria/dea-maps-v8.json
+++ b/dev/terria/dea-maps-v8.json
@@ -1206,7 +1206,7 @@
                             "members": [
                                 {
                                     "type": "wms",
-                                    "name": "DEA Intertidal Elevation (NIDEM)",
+                                    "name": "DEA Intertidal Elevation (Landsat)",
                                     "url": "https://ows.dea.ga.gov.au/",
                                     "opacity": 1,
                                     "layers": "NIDEM",
@@ -1223,7 +1223,7 @@
                                 },
                                 {
                                     "type": "wms",
-                                    "name": "DEA Intertidal Extents (ITEM)",
+                                    "name": "DEA Intertidal Extents (Landsat)",
                                     "url": "https://ows.dea.ga.gov.au/",
                                     "opacity": 1,
                                     "layers": "ITEM_V2.0.0",

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -3254,7 +3254,7 @@
                             "members": [
                                 {
                                     "type": "wms",
-                                    "name": "DEA Intertidal Elevation (NIDEM)",
+                                    "name": "DEA Intertidal Elevation (Landsat)",
                                     "url": "https://ows.dea.ga.gov.au/",
                                     "opacity": 1,
                                     "layers": "NIDEM",
@@ -3271,7 +3271,7 @@
                                 },
                                 {
                                     "type": "wms",
-                                    "name": "DEA Intertidal Extents (ITEM)",
+                                    "name": "DEA Intertidal Extents (Landsat)",
                                     "url": "https://ows.dea.ga.gov.au/",
                                     "opacity": 1,
                                     "layers": "ITEM_V2.0.0",

--- a/prod/services/wms/ows_refactored/inland_water/wofs/annual/ows_wofs_annual_cfg.py
+++ b/prod/services/wms/ows_refactored/inland_water/wofs/annual/ows_wofs_annual_cfg.py
@@ -6,7 +6,7 @@ from ows_refactored.inland_water.wofs.styles_wo_cfg import (
 from ows_refactored.ows_reslim_cfg import reslim_standard
 
 c3_statistics_layer = {
-    "title": "Annual Water Observation Statistics - Calendar Year (Landsat)",
+    "title": "DEA Water Observations Calendar Year (Landsat)",
     "name": "ga_ls_wo_fq_cyear_3",
     "abstract": """**Geoscience Australia Water Observations, Annual Frequency Statistics, Calendar Year (Landsat, Collection 3, 30 m, WO-STATS-ANNUAL, 3.1.6).**
 

--- a/prod/services/wms/ows_refactored/inland_water/wofs/multiyear/ows_wofs_summary_cfg.py
+++ b/prod/services/wms/ows_refactored/inland_water/wofs/multiyear/ows_wofs_summary_cfg.py
@@ -5,7 +5,7 @@ from ows_refactored.inland_water.wofs.styles_wo_cfg import (
 from ows_refactored.ows_reslim_cfg import reslim_standard
 
 c3_wofs_layer = {
-    "title": "Multi Year Water Observation Statistics (Landsat)",
+    "title": "DEA Water Observations Multi Year (Landsat)",
     "name": "ga_ls_wo_fq_myear_3",
     "abstract": """**Geoscience Australia Water Observations, Multi Year Frequency Statistics, 1986 to near present (Landsat, Collection 3, 30 m, WO-STATS, Frequency, 3.1.6).**
 

--- a/prod/services/wms/ows_refactored/inland_water/wofs/seasonal/ows_wofs_apr_oct_cfg.py
+++ b/prod/services/wms/ows_refactored/inland_water/wofs/seasonal/ows_wofs_apr_oct_cfg.py
@@ -6,7 +6,7 @@ from ows_refactored.inland_water.wofs.styles_wo_cfg import (
 from ows_refactored.ows_reslim_cfg import reslim_standard
 
 c3_statistics_layer = {
-    "title": "Seasonal Water Observation Statistics - April to October (Landsat)",
+    "title": "DEA Water Observations April to October (Landsat)",
     "name": "ga_ls_wo_fq_apr_oct_3",
     "abstract": """**Geoscience Australia Water Observations, Seasonal Frequency Statistics, April to October (Landsat, Collection 3, 30 m, WO-STATS-APR-OCT, 3.1.6).**
 

--- a/prod/services/wms/ows_refactored/inland_water/wofs/seasonal/ows_wofs_nov_mar_cfg.py
+++ b/prod/services/wms/ows_refactored/inland_water/wofs/seasonal/ows_wofs_nov_mar_cfg.py
@@ -6,7 +6,7 @@ from ows_refactored.inland_water.wofs.styles_wo_cfg import (
 from ows_refactored.ows_reslim_cfg import reslim_standard
 
 c3_statistics_layer = {
-    "title": "Seasonal Water Observation Statistics - November to March (Landsat)",
+    "title": "DEA Water Observations November to March (Landsat)",
     "name": "ga_ls_wo_fq_nov_mar_3",
     "abstract": """**Geoscience Australia Water Observations, Seasonal Frequency Statistics, November to March (Landsat, Collection 3, 30 m, WO-STATS-NOV-MAR, 3.1.6).**
 

--- a/prod/services/wms/ows_refactored/sea_ocean_coast/intertidal/ows_extents_cfg.py
+++ b/prod/services/wms/ows_refactored/sea_ocean_coast/intertidal/ows_extents_cfg.py
@@ -150,7 +150,7 @@ style_item_confidence = {
 }
 
 item_v2_00_layer = {
-    "title": "DEA Intertidal Extents (ITEM)",
+    "title": "DEA Intertidal Extents (Landsat)",
     "name": "ITEM_V2.0.0",
     "abstract": """Intertidal Extents Model 25m 2.0.0 (Extents)
 

--- a/prod/services/wms/ows_refactored/sea_ocean_coast/intertidal/ows_national_cfg.py
+++ b/prod/services/wms/ows_refactored/sea_ocean_coast/intertidal/ows_national_cfg.py
@@ -80,7 +80,7 @@ style_nidem = {
 
 
 layer = {
-    "title": "DEA Intertidal Elevation (NIDEM)",
+    "title": "DEA Intertidal Elevation (Landsat)",
     "name": "NIDEM",
     "abstract": """National Intertidal Digital Elevation Model 25m 1.0.0
 


### PR DESCRIPTION
This PR makes two updates to our DEA Maps/Terria catalogues, and our dev/prod OWS catalogues:

- Update coastal products to follow naming convention by including "(Landsat)" after name instead of legacy acronym (agreement was to use legacy acronym is used in the folder above instead)
- I also noticed that we never updated the Collection 3 WO layers to follow the naming convention. I've updated these on dev and prod to match [the naming convention spreadsheet](https://geoscienceau.sharepoint.com/:x:/r/sites/DEACoreTeam/Shared%20Documents/Project%20Management%20Documents/Naming%20Conventions%20-%20Collection%20Upgrade.xlsx?d=w0d31ad9865e74114ad8f642cce1816c2&csf=1&web=1&e=Wndd90) and [the names on DEA Maps/Terria](https://maps.dea.ga.gov.au/#share=s-rclc5DHBcQxhZNja2mToUMf7bZ5)

e.g.
> "Seasonal Water Observation Statistics - April to October (Landsat)" 

to:

> "DEA Water Observations April to October (Landsat)"