### PR TITLE
Remove geomedian fy aliases

### DIFF
--- a/products/baseline_satellite_data/geomedian-au/ga_ls5t_nbart_gm_fyear_3.yaml
+++ b/products/baseline_satellite_data/geomedian-au/ga_ls5t_nbart_gm_fyear_3.yaml
@@ -10,41 +10,27 @@ metadata:
     name: ga_ls5t_nbart_gm_fyear_3
 
 measurements:
-  - name: nbart_blue
-    aliases:
-      - blue
+  - name: blue
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_green
-    aliases:
-      - green
+  - name: green
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_red
-    aliases:
-      - red
+  - name: red
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_nir
-    aliases:
-      - nir
+  - name: nir
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_swir_1
-    aliases:
-      - swir_1
-      - swir1
+  - name: swir1
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_swir_2
-    aliases:
-      - swir_2
-      - swir2
+  - name: swir2
     dtype: int16
     nodata: -999
     units: '1'

--- a/products/baseline_satellite_data/geomedian-au/ga_ls7e_nbart_gm_fyear_3.yaml
+++ b/products/baseline_satellite_data/geomedian-au/ga_ls7e_nbart_gm_fyear_3.yaml
@@ -10,41 +10,27 @@ metadata:
     name: ga_ls7e_nbart_gm_fyear_3
 
 measurements:
-  - name: nbart_blue
-    aliases:
-      - blue
+  - name: blue
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_green
-    aliases:
-      - green
+  - name: green
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_red
-    aliases:
-      - red
+  - name: red
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_nir
-    aliases:
-      - nir
+  - name: nir
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_swir_1
-    aliases:
-      - swir_1
-      - swir1
+  - name: swir1
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_swir_2
-    aliases:
-      - swir_2
-      - swir2
+  - name: swir2
     dtype: int16
     nodata: -999
     units: '1'

--- a/products/baseline_satellite_data/geomedian-au/ga_ls8c_nbart_gm_fyear_3.yaml
+++ b/products/baseline_satellite_data/geomedian-au/ga_ls8c_nbart_gm_fyear_3.yaml
@@ -10,41 +10,27 @@ metadata:
     name: ga_ls8c_nbart_gm_fyear_3
 
 measurements:
-  - name: nbart_blue
-    aliases:
-      - blue
+  - name: blue
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_green
-    aliases:
-      - green
+  - name: green
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_red
-    aliases:
-      - red
+  - name: red
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_nir
-    aliases:
-      - nir
+  - name: nir
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_swir_1
-    aliases:
-      - swir_1
-      - swir1
+  - name: swir1
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nbart_swir_2
-    aliases:
-      - swir_2
-      - swir2
+  - name: swir2
     dtype: int16
     nodata: -999
     units: '1'


### PR DESCRIPTION
Remove changed names for geomedian measurements from FY product definitions (at least temporarily). I've run some sample years for testing, but am not using the latest odc-stats image which [has changed to use aliases instead](https://github.com/opendatacube/odc-stats/pull/51)

```
$ s3-to-dc s3://dea-public-data-dev/derivative/ga_ls5t_nbart_gm_fyear_3/3-0-0/**/*.odc-metadata.yaml ga_ls5t_nbart_gm_fyear_3

...
ERROR:root:Failed to index dataset s3://dea-public-data-dev/derivative/ga_ls5t_nbart_gm_fyear_3/3-0-0/x50/y26/2010-07-01--P1Y/ga_ls5t_nbart_gm_fyear_3_x50y26_2010-07-01--P1Y_final.odc-metadata.yaml with error Failed to create dataset with error The dataset is not specifying all of the measurements in this product.
Missing fields are;
{'nbart_swir_1', 'nbart_swir_2', 'nbart_nir', 'nbart_blue', 'nbart_red', 'nbart_green'}
 The URI was s3://dea-public-data-dev/derivative/ga_ls5t_nbart_gm_fyear_3/3-0-0/x50/y26/2010-07-01--P1Y/ga_ls5t_nbart_gm_fyear_3_x50y26_2010-07-01--P1Y_final.odc-metadata.yaml
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/odc/apps/dc_tools/s3_to_dc.py", line 58, in dump_to_odc
    index_update_dataset(metadata, uri, dc, doc2ds, update, update_if_exists, allow_unsafe)
  File "/usr/local/lib/python3.8/dist-packages/odc/apps/dc_tools/utils.py", line 179, in index_update_dataset
    raise IndexingException(
odc.apps.dc_tools.utils.IndexingException: Failed to create dataset with error The dataset is not specifying all of the measurements in this product.
Missing fields are;
{'nbart_swir_1', 'nbart_swir_2', 'nbart_nir', 'nbart_blue', 'nbart_red', 'nbart_green'}
 The URI was s3://dea-public-data-dev/derivative/ga_ls5t_nbart_gm_fyear_3/3-0-0/x50/y26/2010-07-01--P1Y/ga_ls5t_nbart_gm_fyear_3_x50y26_2010-07-01--P1Y_final.odc-metadata.yaml
Added 0 datasets and failed 1035 datasets.
```