### PR TITLE
Add default empty plugin_config for mangroves odc-stats config

### DIFF
--- a/dev/services/odc-stats/mangroves/ga_ls_mangrove_cover_fyear_3.yaml
+++ b/dev/services/odc-stats/mangroves/ga_ls_mangrove_cover_fyear_3.yaml
@@ -50,3 +50,4 @@ s3_acl: public-read
 cog_opts:
   zlevel: 9
 apply_eodatasets3: True
+plugin_config: {}


### PR DESCRIPTION
Current odc-stats doesn't expect dynamic config. Was fixed in https://github.com/opendatacube/odc-stats/pull/54. Changing odc-stats config until that PR gets merged.

```
Stream closed EOF for processing/mangroves-fy-2010-1244291362 (wait)
wait time="2022-06-26T13:22:35.461Z" level=info msg="Main container completed"
wait time="2022-06-26T13:22:35.461Z" level=info msg="No Script output reference in workflow. Capturing script output ignored"
wait time="2022-06-26T13:22:35.461Z" level=info msg="Saving logs"
wait time="2022-06-26T13:22:35.462Z" level=info msg="S3 Save path: /tmp/argo/outputs/logs/main.log, key: mangroves-fy-2010/mangroves-fy-2010-1244291362/main.log"
wait time="2022-06-26T13:22:35.462Z" level=info msg="Creating minio client using static credentials" endpoint=s3.ap-southeast-2.amazonaws.com
wait time="2022-06-26T13:22:35.462Z" level=info msg="Saving file to s3" bucket=dea-dev-argo endpoint=s3.ap-southeast-2.amazonaws.com key=mangroves-fy-2010/mangroves-fy-2010-1244291362/main.log path=/tmp/argo/outputs/logs/main.log
wait time="2022-06-26T13:22:35.554Z" level=info msg="not deleting local artifact" localArtPath=/tmp/argo/outputs/logs/main.log
wait time="2022-06-26T13:22:35.554Z" level=info msg="Successfully saved file: /tmp/argo/outputs/logs/main.log"
wait time="2022-06-26T13:22:35.554Z" level=info msg="No output parameters"
wait time="2022-06-26T13:22:35.554Z" level=info msg="No output artifacts"
wait time="2022-06-26T13:22:35.554Z" level=info msg="Annotating pod with output"
wait time="2022-06-26T13:22:35.578Z" level=info msg="Patch pods 200"
wait time="2022-06-26T13:22:35.584Z" level=info msg="Killing sidecars []"
wait time="2022-06-26T13:22:35.584Z" level=info msg="Alloc=8491 TotalAlloc=16954 Sys=76113 NumGC=5 Goroutines=9"
main time="2022-06-26T13:22:32.481Z" level=info msg="capturing logs" argo=true
main plugin-config
main cli options --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/dev/services/odc-stats/mangroves/ga_ls_mangrove_cover_fyear_3.yaml --location s3://dea-public-data-dev/derivative/ga_ls_mangrove_cover_fyear_3/2-0-2 --plugin-config {mangroves_extent: /tmp/artifacts/maximum_extent_of_mangroves_Apr2019.shp}
main [2022-06-26 13:22:34,909] {_cli_run.py:139} INFO - Config overrides: {'filedb': '/tmp/artifacts/mangroves_fy.db', 'threads': 2, 'memory_limit': '8Gi', 'output_location': 's3://dea-public-data-dev/derivative/ga_ls_mangrove_cover_fyear_3/2-0-2', 'heartbeat_filepath': '/tmp/stats-heartbeat.txt'}
main Traceback (most recent call last):
main   File "/usr/local/bin/odc-stats", line 8, in <module>
main     sys.exit(main())
main   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1130, in __call__
main     return self.main(*args, **kwargs)
main   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1055, in main
main     rv = self.invoke(ctx)
main   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1657, in invoke
main     return _process_result(sub_ctx.command.invoke(sub_ctx))
main   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1404, in invoke
main     return ctx.invoke(self.callback, **ctx.params)
main   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 760, in invoke
main     return __callback(*args, **kwargs)
main   File "/usr/local/lib/python3.8/dist-packages/odc/stats/_cli_run.py", line 143, in run
main     _cfg["plugin_config"].update(plugin_config)
main KeyError: 'plugin_config'
main Error: exit status 1
Stream closed EOF for processing/mangroves-fy-2010-1244291362 (init)
Stream closed EOF for processing/mangroves-fy-2010-1244291362 (main)
```