### PR TITLE
Set getFeatureInfoFormat to `xml` for problematic WMS servers

### DIFF
--- a/dev/terria/dea-maps-v8.json
+++ b/dev/terria/dea-maps-v8.json
@@ -1184,7 +1184,13 @@
                                             "url": "http://services.ga.gov.au/gis/services/Geomorphology_Smartline/MapServer/WMSServer",
                                             "excludeMembers": [
                                                 "Geomorphic Smartline"
-                                            ]
+                                            ],
+                                            "itemProperties": {
+                                                "getFeatureInfoFormat": {
+                                                "type": "xml",
+                                                "format": "text/xml"
+                                                }
+                                            }
                                         },
                                         {
                                             "id": "fhty455",
@@ -1193,7 +1199,13 @@
                                             "url": "http://services.ga.gov.au/gis/services/Australian_Coastal_Sediment_Compartments/MapServer/WMSServer",
                                             "excludeMembers": [
                                                 "Geomorphic Smartline"
-                                            ]
+                                            ],
+                                            "itemProperties": {
+                                                "getFeatureInfoFormat": {
+                                                "type": "xml",
+                                                "format": "text/xml"
+                                                }
+                                            }
                                         }
                                     ]
                                 }


### PR DESCRIPTION
- http://services.ga.gov.au/gis/services/Geomorphology_Smartline/MapServer/WMSServer
- http://services.ga.gov.au/gis/services/Australian_Coastal_Sediment_Compartments/MapServer/WMSServer

These both advertise `GetFeatureInfo` supports `text/html` format, but both return gibberish

![image](https://user-images.githubusercontent.com/6187649/180931074-c40405f2-482b-4a72-9513-667921f02e2e.png)

Example `GetFeatureInfo` request with `info_format=text/html`

- http://services.ga.gov.au/gis/services/Australian_Coastal_Sediment_Compartments/MapServer/WMSServer?exceptions=XML&version=1.3.0&feature_count=101&crs=EPSG%3A3857&styles=default&service=WMS&request=GetFeatureInfo&layers=Primary_compartments&bbox=13775786.985667605%2C-2504688.542848654%2C15028131.257091936%2C-1252344.271424327&width=256&height=256&query_layers=Primary_compartments&info_format=text%2Fhtml&i=45&j=65

This PR changes `info_format=text/xml` so you get a correct response

- http://services.ga.gov.au/gis/services/Australian_Coastal_Sediment_Compartments/MapServer/WMSServer?exceptions=XML&version=1.3.0&feature_count=101&crs=EPSG%3A3857&styles=default&service=WMS&request=GetFeatureInfo&layers=Primary_compartments&bbox=13775786.985667605%2C-2504688.542848654%2C15028131.257091936%2C-1252344.271424327&width=256&height=256&query_layers=Primary_compartments&info_format=text%2Fxml&i=45&j=65

### Before

https://maps.dea.ga.gov.au/#share=s-gE7yvKqrke2rMqf5DW4zREGD9gi

![image](https://user-images.githubusercontent.com/6187649/180930863-adc25efe-c55c-4578-969c-46be0be86c14.png)

### After

https://maps.dea.ga.gov.au/#share=s-gE7yvKqrke2rMqf5DW4zREGD9gi&clean&https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/661bda4a156cee2e8e9f9de77a34e6a344a91aff/dev/terria/dea-maps-v8.json

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/6187649/180930926-68197237-293f-46b5-8d7f-1a2ba640ec47.png">

