### PR TITLE
Add pansharpened style to Landsat 7

### DIFF
--- a/dev/services/wms/inventory.json
+++ b/dev/services/wms/inventory.json
@@ -272,15 +272,15 @@
                 "ndwi",
                 "mndwi",
                 "nbr",
+                "aerosol",
                 "blue",
                 "green",
                 "red",
                 "nir",
                 "swir1",
                 "swir2",
-                "fmask",
                 "panchromatic",
-                "aerosol"
+                "fmask"
             ]
         },
         {
@@ -303,8 +303,8 @@
                 "nir",
                 "swir1",
                 "swir2",
-                "fmask",
-                "panchromatic"
+                "panchromatic",
+                "fmask"
             ]
         },
         {
@@ -337,21 +337,21 @@
             "styles_count": 16,
             "styles_list": [
                 "true_colour",
+                "true_colour_pan",
                 "false_colour",
                 "ndvi",
                 "ndwi",
                 "mndwi",
                 "nbr",
+                "aerosol",
                 "blue",
                 "green",
                 "red",
                 "nir",
                 "swir1",
                 "swir2",
-                "fmask",
                 "panchromatic",
-                "aerosol",
-                "true_colour_pan"
+                "fmask"
             ]
         },
         {
@@ -359,9 +359,10 @@
             "product": [
                 "ga_ls7e_ard_provisional_3"
             ],
-            "styles_count": 14,
+            "styles_count": 15,
             "styles_list": [
                 "true_colour",
+                "true_colour_pan",
                 "false_colour",
                 "ndvi",
                 "ndwi",
@@ -373,8 +374,8 @@
                 "nir",
                 "swir1",
                 "swir2",
-                "fmask",
-                "panchromatic"
+                "panchromatic",
+                "fmask"
             ]
         },
         {

--- a/dev/services/wms/inventory.json
+++ b/dev/services/wms/inventory.json
@@ -266,6 +266,7 @@
             "styles_count": 16,
             "styles_list": [
                 "true_colour",
+                "true_colour_pan",
                 "false_colour",
                 "ndvi",
                 "ndwi",
@@ -279,8 +280,7 @@
                 "swir2",
                 "fmask",
                 "panchromatic",
-                "aerosol",
-                "true_colour_pan"
+                "aerosol"
             ]
         },
         {
@@ -288,9 +288,10 @@
             "product": [
                 "ga_ls7e_ard_3"
             ],
-            "styles_count": 14,
+            "styles_count": 15,
             "styles_list": [
                 "true_colour",
+                "true_colour_pan",
                 "false_colour",
                 "ndvi",
                 "ndwi",

--- a/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/style_c3_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/style_c3_cfg.py
@@ -601,6 +601,7 @@ styles_c3_ls_common = [
 
 styles_c3_ls_7 = styles_c3_ls_common.copy()
 styles_c3_ls_7.append(style_c3_ls7_pure_panchromatic)
+styles_c3_ls_7.append(style_c3_true_colour_pan)
 
 styles_c3_ls_8 = styles_c3_ls_common.copy()
 styles_c3_ls_8.append(style_c3_ls8_pure_panchromatic)


### PR DESCRIPTION
This PR adds the panchromatic true colour style to Landsat 7, and makes some minor updates to use a more logical order for the styles (panchromatic true colour next to true colour, bands in order of band number).