### PR TITLE
Use primary band name for s2cloudless_mask OWS layers

### DIFF
--- a/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/band_s2_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/band_s2_cfg.py
@@ -47,8 +47,8 @@ bands_sentinel2_c3 = {
     "nbart_swir_2": ["nbart_swir_2", "swir_2", "nbart_shortwave_infrared_2"],
     "nbart_swir_3": ["nbart_swir_3", "swir_3", "nbart_shortwave_infrared_3"],
     "oa_fmask": ["oa_fmask", "fmask"],
-    "s2cloudless_mask": ["s2cloudless_mask"],
-    "s2cloudless_prob": ["s2cloudless_prob"],
+    "oa_s2cloudless_mask": ["oa_s2cloudless_mask", "s2cloudless_mask"],
+    "oa_s2cloudless_prob": ["oa_s2cloudless_prob", "s2cloudless_prob"],
 }
 
 bands_sentinel2_provisional = {

--- a/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/ows_ard_c3_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/ows_ard_c3_cfg.py
@@ -6,7 +6,7 @@ from ows_refactored.ows_reslim_cfg import reslim_for_sentinel2
 
 s2b_c3_layer = {
     "name": "ga_s2bm_ard_3",
-    "title": "DEA Surface Reflectance (Sentinel-2B MSI) Collection 3",
+    "title": "DEA Surface Reflectance (Sentinel-2B MSI, Collection 3)",
     "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2B MSI)
 
 This product has been corrected to account for variations caused by atmospheric properties, sun position and sensor view angle at time of image capture.
@@ -33,7 +33,7 @@ For service status information, see https://status.dea.ga.gov.au""",
     },
     "flags": [
         {
-            "band": "s2cloudless_mask",
+            "band": "oa_s2cloudless_mask",
             "product": "ga_s2bm_ard_3",
             "ignore_time": False,
             "ignore_info_flags": []
@@ -50,7 +50,7 @@ For service status information, see https://status.dea.ga.gov.au""",
 
 s2a_c3_layer = {
     "name": "ga_s2am_ard_3",
-    "title": "DEA Surface Reflectance (Sentinel-2A MSI) Collection 3",
+    "title": "DEA Surface Reflectance (Sentinel-2A MSI, Collection 3)",
     "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2A MSI)
 
 This product takes Sentinel-2A imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
@@ -77,7 +77,7 @@ For service status information, see https://status.dea.ga.gov.au""",
     },
     "flags": [
         {
-            "band": "s2cloudless_mask",
+            "band": "oa_s2cloudless_mask",
             "product": "ga_s2am_ard_3",
             "ignore_time": False,
             "ignore_info_flags": []
@@ -93,7 +93,7 @@ For service status information, see https://status.dea.ga.gov.au""",
 }
 
 combined_layer = {
-    "title": "DEA Surface Reflectance (Sentinel-2 MSI) Collection 3",
+    "title": "DEA Surface Reflectance (Sentinel-2 MSI, Collection 3)",
     "name": "ga_s2m_ard_3",
     "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2 MSI)
 
@@ -122,7 +122,7 @@ For service status information, see https://status.dea.ga.gov.au""",
     },
     "flags": [
         {
-            "band": "s2cloudless_mask",
+            "band": "oa_s2cloudless_mask",
             "products": ["ga_s2am_ard_3", "ga_s2bm_ard_3"],
             "ignore_time": False,
             "ignore_info_flags": []

--- a/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/style_s2_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/style_s2_cfg.py
@@ -35,7 +35,7 @@ s2_provisional_oa_fmask = [
 
 s2_c3_cloudless_mask = [
     {
-        "band": "s2cloudless_mask",
+        "band": "oa_s2cloudless_mask",
         "values": [0, 2, 3],
         "invert": True,
     },


### PR DESCRIPTION
This fixes the issue when running `datacube-ows-update` - it seems to not pick up the alias `s2cloudless_mask` for flag bands.

```
Could not load layer DEA Surface Reflectance (Sentinel-2 MSI) Collection 3: Unknown band: s2cloudless_mask in layer ga_s2m_ard_3
Could not load layer DEA Surface Reflectance (Sentinel-2A MSI) Collection 3: Unknown band: s2cloudless_mask in layer ga_s2am_ard_3
Could not load layer DEA Surface Reflectance (Sentinel-2B MSI) Collection 3: Unknown band: s2cloudless_mask in layer ga_s2bm_ard_3
```

So use the primary band name of `oa_s2cloudless_mask` instead.