### PR TITLE
Change WO alchemist config to inherit maturity from ARD

### DIFF
--- a/dev/services/alchemist/ga_ls_wo_3/ga_ls_wo_3.alchemist.yaml
+++ b/dev/services/alchemist/ga_ls_wo_3/ga_ls_wo_3.alchemist.yaml
@@ -46,9 +46,6 @@ output:
     collection_number: 3
     naming_conventions: dea_c3
 
-  properties:
-    dea:dataset_maturity: interim
-
 processing:
   dask_chunks:
     x: -1


### PR DESCRIPTION
With [Alchemist updated to use parent dataset maturity](https://github.com/opendatacube/datacube-alchemist/pull/155), remove specific maturity from the config