### PR TITLE
Standardise CRS format across product definitions

### DIFF
--- a/products/baseline_satellite_data/c3/ga_ls5t_ard_3.odc-product.yaml
+++ b/products/baseline_satellite_data/c3/ga_ls5t_ard_3.odc-product.yaml
@@ -167,7 +167,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -30
     x: 30

--- a/products/baseline_satellite_data/c3/ga_ls7e_ard_3.odc-product.yaml
+++ b/products/baseline_satellite_data/c3/ga_ls7e_ard_3.odc-product.yaml
@@ -174,7 +174,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -30
     x: 30

--- a/products/baseline_satellite_data/c3/ga_ls8c_ard_3.odc-product.yaml
+++ b/products/baseline_satellite_data/c3/ga_ls8c_ard_3.odc-product.yaml
@@ -181,7 +181,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -30
     x: 30

--- a/products/baseline_satellite_data/c3/ga_ls9c_ard_3.odc-product.yaml
+++ b/products/baseline_satellite_data/c3/ga_ls9c_ard_3.odc-product.yaml
@@ -181,7 +181,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -30
     x: 30

--- a/products/baseline_satellite_data/c3/ga_s2am_ard_3.odc-product.yaml
+++ b/products/baseline_satellite_data/c3/ga_s2am_ard_3.odc-product.yaml
@@ -221,7 +221,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/baseline_satellite_data/c3/ga_s2bm_ard_3.odc-product.yaml
+++ b/products/baseline_satellite_data/c3/ga_s2bm_ard_3.odc-product.yaml
@@ -221,7 +221,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/baseline_satellite_data/definitive/s2a_ard_granule.odc-product.yaml
+++ b/products/baseline_satellite_data/definitive/s2a_ard_granule.odc-product.yaml
@@ -328,7 +328,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/baseline_satellite_data/definitive/s2b_ard_granule.odc-product.yaml
+++ b/products/baseline_satellite_data/definitive/s2b_ard_granule.odc-product.yaml
@@ -355,7 +355,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/baseline_satellite_data/ga_s2_ard_nbar/ga_s2a_ard_nbar_granule.odc-product.yaml
+++ b/products/baseline_satellite_data/ga_s2_ard_nbar/ga_s2a_ard_nbar_granule.odc-product.yaml
@@ -338,7 +338,7 @@ metadata_type: eo_plus
 name: ga_s2a_ard_nbar_granule
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/baseline_satellite_data/ga_s2_ard_nbar/ga_s2b_ard_nbar_granule.odc-product.yaml
+++ b/products/baseline_satellite_data/ga_s2_ard_nbar/ga_s2b_ard_nbar_granule.odc-product.yaml
@@ -365,7 +365,7 @@ metadata_type: eo_plus
 name: ga_s2b_ard_nbar_granule
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/baseline_satellite_data/geomedian-au/ga_ls5t_nbart_gm_cyear_3.odc-product.yaml
+++ b/products/baseline_satellite_data/geomedian-au/ga_ls5t_nbart_gm_cyear_3.odc-product.yaml
@@ -53,7 +53,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/baseline_satellite_data/geomedian-au/ga_ls5t_nbart_gm_fyear_3.odc-product.yaml
+++ b/products/baseline_satellite_data/geomedian-au/ga_ls5t_nbart_gm_fyear_3.odc-product.yaml
@@ -67,7 +67,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/baseline_satellite_data/geomedian-au/ga_ls7e_nbart_gm_cyear_3.odc-product.yaml
+++ b/products/baseline_satellite_data/geomedian-au/ga_ls7e_nbart_gm_cyear_3.odc-product.yaml
@@ -53,7 +53,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/baseline_satellite_data/geomedian-au/ga_ls7e_nbart_gm_fyear_3.odc-product.yaml
+++ b/products/baseline_satellite_data/geomedian-au/ga_ls7e_nbart_gm_fyear_3.odc-product.yaml
@@ -67,7 +67,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/baseline_satellite_data/geomedian-au/ga_ls8c_nbart_gm_cyear_3.odc-product.yaml
+++ b/products/baseline_satellite_data/geomedian-au/ga_ls8c_nbart_gm_cyear_3.odc-product.yaml
@@ -53,7 +53,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/baseline_satellite_data/geomedian-au/ga_ls8c_nbart_gm_fyear_3.odc-product.yaml
+++ b/products/baseline_satellite_data/geomedian-au/ga_ls8c_nbart_gm_fyear_3.odc-product.yaml
@@ -67,7 +67,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/baseline_satellite_data/nrt/sentinel/s2a_nrt.odc-product.yaml
+++ b/products/baseline_satellite_data/nrt/sentinel/s2a_nrt.odc-product.yaml
@@ -796,7 +796,7 @@ measurements:
                        2319, 2320]
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/baseline_satellite_data/nrt/sentinel/s2b_nrt.odc-product.yaml
+++ b/products/baseline_satellite_data/nrt/sentinel/s2b_nrt.odc-product.yaml
@@ -889,7 +889,7 @@ measurements:
                        2297, 2298, 2299, 2300, 2301, 2302, 2303]
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/baseline_satellite_data/provisional/ard_ls7_provisional.odc-product.yaml
+++ b/products/baseline_satellite_data/provisional/ard_ls7_provisional.odc-product.yaml
@@ -176,7 +176,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -30
     x: 30

--- a/products/baseline_satellite_data/provisional/ard_ls8_provisional.odc-product.yaml
+++ b/products/baseline_satellite_data/provisional/ard_ls8_provisional.odc-product.yaml
@@ -183,7 +183,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -30
     x: 30

--- a/products/baseline_satellite_data/provisional/ard_s2a_provisional.odc-product.yaml
+++ b/products/baseline_satellite_data/provisional/ard_s2a_provisional.odc-product.yaml
@@ -201,7 +201,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/baseline_satellite_data/provisional/ard_s2b_provisional.odc-product.yaml
+++ b/products/baseline_satellite_data/provisional/ard_s2b_provisional.odc-product.yaml
@@ -201,7 +201,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/hazards/burntarea/ga_s2_ba_provisional_3.odc-product.yaml
+++ b/products/hazards/burntarea/ga_s2_ba_provisional_3.odc-product.yaml
@@ -33,7 +33,7 @@ measurements:
     nodata: .nan
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/inland_water/c3_tc/ga_ls_tc_pc_cyear_3.odc-product.yaml
+++ b/products/inland_water/c3_tc/ga_ls_tc_pc_cyear_3.odc-product.yaml
@@ -54,7 +54,7 @@ measurements:
     nodata: -9999
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/inland_water/c3_tc/ga_ls_tc_pc_fyear_3.odc-product.yaml
+++ b/products/inland_water/c3_tc/ga_ls_tc_pc_fyear_3.odc-product.yaml
@@ -54,7 +54,7 @@ measurements:
     nodata: -9999
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/inland_water/c3_wo/ga_ls_wo_3.odc-product.yaml
+++ b/products/inland_water/c3_wo/ga_ls_wo_3.odc-product.yaml
@@ -59,7 +59,7 @@ measurements:
         values: {128: true}
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -30
     x: 30

--- a/products/inland_water/ga_ls_tcw_percentiles_2/ga_ls_tcw_percentiles_2.odc-product.yaml
+++ b/products/inland_water/ga_ls_tcw_percentiles_2/ga_ls_tcw_percentiles_2.odc-product.yaml
@@ -26,7 +26,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -25
     x: 25

--- a/products/inland_water/s2_wo/ga_s2_nrt_c3_wo.odc-product.yaml
+++ b/products/inland_water/s2_wo/ga_s2_nrt_c3_wo.odc-product.yaml
@@ -90,7 +90,7 @@ measurements:
       description: Low solar incidence angle
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/inland_water/s2_wo/ga_s2_wo_3.odc-product.yaml
+++ b/products/inland_water/s2_wo/ga_s2_wo_3.odc-product.yaml
@@ -87,7 +87,7 @@ measurements:
       description: Low solar incidence angle
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/inland_water/wofs/ga_ls_wo_fq_apr_oct_3.odc-product.yaml
+++ b/products/inland_water/wofs/ga_ls_wo_fq_apr_oct_3.odc-product.yaml
@@ -25,7 +25,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/inland_water/wofs/ga_ls_wo_fq_cyear_3.odc-product.yaml
+++ b/products/inland_water/wofs/ga_ls_wo_fq_cyear_3.odc-product.yaml
@@ -25,7 +25,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/inland_water/wofs/ga_ls_wo_fq_fyear_3.odc-product.yaml
+++ b/products/inland_water/wofs/ga_ls_wo_fq_fyear_3.odc-product.yaml
@@ -25,7 +25,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/inland_water/wofs/ga_ls_wo_fq_myear_3.odc-product.yaml
+++ b/products/inland_water/wofs/ga_ls_wo_fq_myear_3.odc-product.yaml
@@ -25,7 +25,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/inland_water/wofs/ga_ls_wo_fq_nov_mar_3.odc-product.yaml
+++ b/products/inland_water/wofs/ga_ls_wo_fq_nov_mar_3.odc-product.yaml
@@ -25,7 +25,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/inland_water/wofs/wofs_filtered_summary.odc-product.yaml
+++ b/products/inland_water/wofs/wofs_filtered_summary.odc-product.yaml
@@ -22,7 +22,7 @@ metadata:
     product_type: wofs_filtered_summary
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -25
     x: 25

--- a/products/inland_water/wofs/wofs_summary.odc-product.yaml
+++ b/products/inland_water/wofs/wofs_summary.odc-product.yaml
@@ -26,7 +26,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -25
     x: 25

--- a/products/land_and_vegetation/bare-earth/summary/be_ls_combined_product.odc-product.yaml
+++ b/products/land_and_vegetation/bare-earth/summary/be_ls_combined_product.odc-product.yaml
@@ -52,7 +52,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -25
     x: 25

--- a/products/land_and_vegetation/bare-earth/summary/be_s2_product_definition.odc-product.yaml
+++ b/products/land_and_vegetation/bare-earth/summary/be_s2_product_definition.odc-product.yaml
@@ -103,7 +103,7 @@ measurements:
   - s2be_Band12
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -10
     x: 10

--- a/products/land_and_vegetation/c3_fc/ga_ls_fc_3.odc-product.yaml
+++ b/products/land_and_vegetation/c3_fc/ga_ls_fc_3.odc-product.yaml
@@ -34,7 +34,7 @@ measurements:
     aliases: ["err"]
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -30
     x: 30

--- a/products/land_and_vegetation/fc/ga_ls_fc_pc_cyear_3.odc-product.yaml
+++ b/products/land_and_vegetation/fc/ga_ls_fc_pc_cyear_3.odc-product.yaml
@@ -67,7 +67,7 @@ measurements:
         description: Quality Assurance
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/land_and_vegetation/fc/ga_ls_fc_pc_fyear_3.odc-product.yaml
+++ b/products/land_and_vegetation/fc/ga_ls_fc_pc_fyear_3.odc-product.yaml
@@ -67,7 +67,7 @@ measurements:
         description: Quality Assurance
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/land_and_vegetation/fc/ga_s2am_fractional_cover.odc-product.yaml
+++ b/products/land_and_vegetation/fc/ga_s2am_fractional_cover.odc-product.yaml
@@ -30,7 +30,7 @@ measurements:
       aliases: ["err"]
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/land_and_vegetation/fc/ga_s2bm_fractional_cover.odc-product.yaml
+++ b/products/land_and_vegetation/fc/ga_s2bm_fractional_cover.odc-product.yaml
@@ -30,7 +30,7 @@ measurements:
       aliases: ["err"]
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -10
     x: 10

--- a/products/land_and_vegetation/landcover/ga_ls_landcover_class_cyear_3.odc-product.yaml
+++ b/products/land_and_vegetation/landcover/ga_ls_landcover_class_cyear_3.odc-product.yaml
@@ -66,7 +66,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/land_and_vegetation/landcover/ga_ls_landcover_class_fyear_3.odc-product.yaml
+++ b/products/land_and_vegetation/landcover/ga_ls_landcover_class_fyear_3.odc-product.yaml
@@ -66,7 +66,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/land_and_vegetation/landcover/lc_ls_c2.odc-product.yaml
+++ b/products/land_and_vegetation/landcover/lc_ls_c2.odc-product.yaml
@@ -66,7 +66,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -25
     x: 25

--- a/products/land_and_vegetation/ls8-bare-earth/landsat8_barest_earth_albers.odc-product.yaml
+++ b/products/land_and_vegetation/ls8-bare-earth/landsat8_barest_earth_albers.odc-product.yaml
@@ -39,7 +39,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -25
     x: 25

--- a/products/land_and_vegetation/ls8-bare-earth/landsat8_barest_earth_mosaic.odc-product.yaml
+++ b/products/land_and_vegetation/ls8-bare-earth/landsat8_barest_earth_mosaic.odc-product.yaml
@@ -38,7 +38,7 @@ measurements:
     units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -25
     x: 25

--- a/products/land_and_vegetation/mangrove/ga_ls_mangrove_cover_cyear_3.odc-product.yaml
+++ b/products/land_and_vegetation/mangrove/ga_ls_mangrove_cover_cyear_3.odc-product.yaml
@@ -31,7 +31,7 @@ measurements:
         values: {3: true}
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/land_and_vegetation/mangrove/ga_ls_mangrove_cover_fyear_3.odc-product.yaml
+++ b/products/land_and_vegetation/mangrove/ga_ls_mangrove_cover_fyear_3.odc-product.yaml
@@ -31,7 +31,7 @@ measurements:
         values: {3: true}
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -30
     x: 30

--- a/products/sea_ocean_coast/geodata_coast_100k/geodata_coast_100k.odc-product.yaml
+++ b/products/sea_ocean_coast/geodata_coast_100k/geodata_coast_100k.odc-product.yaml
@@ -37,7 +37,7 @@ measurements:
   units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution: 
     y: -25
     x: 25

--- a/products/sea_ocean_coast/hltc/high_tide_comp_20p.odc-product.yaml
+++ b/products/sea_ocean_coast/hltc/high_tide_comp_20p.odc-product.yaml
@@ -43,7 +43,7 @@ measurements:
       units: 'metres'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -25
     x: 25

--- a/products/sea_ocean_coast/hltc/low_tide_compo_20p.odc-product.yaml
+++ b/products/sea_ocean_coast/hltc/low_tide_compo_20p.odc-product.yaml
@@ -46,7 +46,7 @@ measurements:
       units: 'metres'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -25
     x: 25

--- a/products/sea_ocean_coast/item/item_v2.odc-product.yaml
+++ b/products/sea_ocean_coast/item/item_v2.odc-product.yaml
@@ -18,7 +18,7 @@ measurements:
   units: '0.1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -25
     x: 25

--- a/products/sea_ocean_coast/item/item_v2_conf.odc-product.yaml
+++ b/products/sea_ocean_coast/item/item_v2_conf.odc-product.yaml
@@ -21,7 +21,7 @@ measurements:
   units: '1'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -25
     x: 25

--- a/products/sea_ocean_coast/nidem/nidem.odc-product.yaml
+++ b/products/sea_ocean_coast/nidem/nidem.odc-product.yaml
@@ -14,7 +14,7 @@ measurements:
     units: 'metres'
 
 load:
-  crs: 'epsg:3577'
+  crs: 'EPSG:3577'
   resolution:
     y: -25
     x: 25


### PR DESCRIPTION
Currently our product definitions inconsistently define CRSs with upper and lower case. This PR standardises this to use upper case everywhere (currently the format we use across DEA Notebooks and the User Guide too).