### PR TITLE
Remove C3 suffix from S2 data in OWS and Terria

### DIFF
--- a/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/ows_ard_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/ows_ard_cfg.py
@@ -6,7 +6,7 @@ from ows_refactored.ows_reslim_cfg import reslim_for_sentinel2
 
 s2b_layer = {
     "name": "ga_s2bm_ard_3",
-    "title": "DEA Surface Reflectance (Sentinel-2B MSI, Collection 3)",
+    "title": "DEA Surface Reflectance (Sentinel-2B MSI)",
     "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2B MSI)
 
 This product has been corrected to account for variations caused by atmospheric properties, sun position and sensor view angle at time of image capture.
@@ -50,7 +50,7 @@ For service status information, see https://status.dea.ga.gov.au""",
 
 s2a_layer = {
     "name": "ga_s2am_ard_3",
-    "title": "DEA Surface Reflectance (Sentinel-2A MSI, Collection 3)",
+    "title": "DEA Surface Reflectance (Sentinel-2A MSI)",
     "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2A MSI)
 
 This product takes Sentinel-2A imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
@@ -93,7 +93,7 @@ For service status information, see https://status.dea.ga.gov.au""",
 }
 
 combined_layer = {
-    "title": "DEA Surface Reflectance (Sentinel-2 MSI, Collection 3)",
+    "title": "DEA Surface Reflectance (Sentinel-2 MSI)",
     "name": "ga_s2m_ard_3",
     "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2 MSI)
 

--- a/dev/terria/dea-maps-v8.json
+++ b/dev/terria/dea-maps-v8.json
@@ -55,7 +55,7 @@
                         },
                         {
                             "type": "wms",
-                            "name": "DEA Surface Reflectance (Sentinel-2, Collection 3)",
+                            "name": "DEA Surface Reflectance (Sentinel-2)",
                             "url": "https://ows.dea.ga.gov.au/",
                             "opacity": 1,
                             "layers": "ga_s2m_ard_3",
@@ -80,7 +80,7 @@
                             "tileErrorHandlingOptions": {
                                 "ignoreUnknownTileErrors": true
                             },
-                            "id": "uKwnEz",
+                            "id": "SbBCvf",
                             "shareKeys": [
                                 "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 satellite imagery archive/Sentinel 2 satellite images"
                             ]
@@ -379,7 +379,7 @@
                             "members": [
                                 {
                                     "type": "wms",
-                                    "name": "DEA Surface Reflectance (Sentinel-2A MSI, Collection 3)",
+                                    "name": "DEA Surface Reflectance (Sentinel-2A MSI)",
                                     "url": "https://ows.dea.ga.gov.au/",
                                     "opacity": 1,
                                     "layers": "ga_s2am_ard_3",
@@ -408,7 +408,7 @@
                                 },
                                 {
                                     "type": "wms",
-                                    "name": "DEA Surface Reflectance (Sentinel-2B MSI, Collection 3)",
+                                    "name": "DEA Surface Reflectance (Sentinel-2B MSI)",
                                     "url": "https://ows.dea.ga.gov.au/",
                                     "opacity": 1,
                                     "layers": "ga_s2bm_ard_3",

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -57,7 +57,7 @@
                         },
                         {
                             "type": "wms",
-                            "name": "DEA Surface Reflectance (Sentinel-2, Collection 3)",
+                            "name": "DEA Surface Reflectance (Sentinel-2)",
                             "url": "https://ows.dev.dea.ga.gov.au/",
                             "opacity": 1,
                             "layers": "ga_s2m_ard_3",
@@ -82,7 +82,7 @@
                             "tileErrorHandlingOptions": {
                                 "ignoreUnknownTileErrors": true
                             },
-                            "id": "qJzPBD",
+                            "id": "SbBCvf",
                             "shareKeys": [
                                 "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 satellite imagery archive/Sentinel 2 satellite images"
                             ]
@@ -395,7 +395,7 @@
                             "members": [
                                 {
                                     "type": "wms",
-                                    "name": "DEA Surface Reflectance (Sentinel-2A MSI, Collection 3)",
+                                    "name": "DEA Surface Reflectance (Sentinel-2A MSI)",
                                     "url": "https://ows.dev.dea.ga.gov.au/",
                                     "opacity": 1,
                                     "layers": "ga_s2am_ard_3",
@@ -424,7 +424,7 @@
                                 },
                                 {
                                     "type": "wms",
-                                    "name": "DEA Surface Reflectance (Sentinel-2B MSI, Collection 3)",
+                                    "name": "DEA Surface Reflectance (Sentinel-2B MSI)",
                                     "url": "https://ows.dev.dea.ga.gov.au/",
                                     "opacity": 1,
                                     "layers": "ga_s2bm_ard_3",

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -82,7 +82,7 @@
                             "tileErrorHandlingOptions": {
                                 "ignoreUnknownTileErrors": true
                             },
-                            "id": "SbBCvf",
+                            "id": "qJzPBD",
                             "shareKeys": [
                                 "Root Group/Satellite images/Satellite images 10m - daily/Sentinel 2 satellite imagery archive/Sentinel 2 satellite images"
                             ]

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/sentinel2/ows_ard_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/sentinel2/ows_ard_cfg.py
@@ -6,7 +6,7 @@ from ows_refactored.ows_reslim_cfg import reslim_for_sentinel2
 
 s2b_layer = {
     "name": "ga_s2bm_ard_3",
-    "title": "DEA Surface Reflectance (Sentinel-2B MSI, Collection 3)",
+    "title": "DEA Surface Reflectance (Sentinel-2B MSI)",
     "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2B MSI)
 
 This product has been corrected to account for variations caused by atmospheric properties, sun position and sensor view angle at time of image capture.
@@ -50,7 +50,7 @@ For service status information, see https://status.dea.ga.gov.au""",
 
 s2a_layer = {
     "name": "ga_s2am_ard_3",
-    "title": "DEA Surface Reflectance (Sentinel-2A MSI, Collection 3)",
+    "title": "DEA Surface Reflectance (Sentinel-2A MSI)",
     "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2A MSI)
 
 This product takes Sentinel-2A imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
@@ -93,7 +93,7 @@ For service status information, see https://status.dea.ga.gov.au""",
 }
 
 combined_layer = {
-    "title": "DEA Surface Reflectance (Sentinel-2 MSI, Collection 3)",
+    "title": "DEA Surface Reflectance (Sentinel-2 MSI)",
     "name": "ga_s2m_ard_3",
     "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2 MSI)
 


### PR DESCRIPTION
Now that we have only Collection 3 Sentinel-2 data available, we can remove the "Collection 3" suffix from our catalogues. This will make the data less confusing to users who are unlikely to care about the collection the data comes from.

Also swapped the DEA Maps combined Sentinel-2 ID to the older "definitive" vs "near real time" so that old share links are less likely to break.