### PR TITLE
Allow Caching of OWS Responses

### DIFF
--- a/prod/services/wms/ows_refactored/ows_reslim_cfg.py
+++ b/prod/services/wms/ows_refactored/ows_reslim_cfg.py
@@ -3,6 +3,10 @@
 
 dataset_cache_rules = [
     {
+        "min_datasets": 1,
+        "max_age": 60 * 60,
+    },
+    {
         "min_datasets": 5,
         "max_age": 60 * 60 * 24,
     },

--- a/prod/services/wms/ows_refactored/ows_root_cfg.py
+++ b/prod/services/wms/ows_refactored/ows_root_cfg.py
@@ -92,6 +92,8 @@ ows_cfg = {
         "s3_aws_zone": "ap-southeast-2",
         "max_width": 512,
         "max_height": 512,
+        # Allow the WMS/WMTS GetCapabilities responses to be cached for 1 hour
+        "caps_cache_maxage": 3600,
     },  # END OF wms SECTION
     "wmts": {
         # Config for WMTS service, for all products/layers
@@ -123,6 +125,8 @@ ows_cfg = {
     "wcs": {
         # Config for WCS service, for all products/coverages
         "default_geographic_CRS": "EPSG:4326",
+        "caps_cache_maxage": 3600,
+        "default_desc_cache_maxage": 3600,
         "formats": {
             "GeoTIFF": {
                 "renderers": {


### PR DESCRIPTION
At the moment, approximately none (0.44% in the last 30 days) of our OWS traffic is being cached by CloudFront. This is a problem for two reasons. 1: poor performance for OWS Users. 2: Increased load on OWS Application Servers.

This change allows GetCapabilities requests to be cached for 1 hour, and allows GetMaps/GetTile requests to be cached for 1 hour.

Previously, the only requests being cached are those for GetMap/GetTile requests that combine 4 or more datasets.