### PR TITLE
Add new combined S2 and Landsat layer to Terriacube

### DIFF
--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -39,7 +39,7 @@
                             "leafletUpdateInterval": 750,
                             "chartType": "momentPoints",
                             "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Normalised Difference Vegetation Index</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>Normalised Difference Water Index</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>Modified Normalised Difference Water Index</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>Normalised Burn Ratio</b></td><td>{{data.0.band_derived.nbr}}</td></tr></table><p><chart id='{{x}}{{y}}{{time}}' title='NBART at {{x}},{{y}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n840,{{data.0.bands.nbart_nir}}\n1650,{{data.0.bands.nbart_swir1}}\n2220,{{data.0.bands.nbart_swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr></table><p><chart id='{{x}}{{y}}{{time}}' title='NBART at {{x}},{{y}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
                                 "formats": {
                                     "lat": {
                                         "maximumFractionDigits": 5
@@ -2036,7 +2036,7 @@
                     "members": [
                         {
                             "type": "wms",
-                            "name": "DEA Surface Reflectance (Landsat and Sentinel-2)",
+                            "name": "DEA Surface Reflectance (Landsat and Sentinel-2, GSKY)",
                             "url": "https://gsky.nci.org.au/ows/dea",
                             "opacity": 1,
                             "layers": "blend_sentinel2_landsat_nbart_daily",
@@ -2051,6 +2051,34 @@
                             "shareKeys": [
                                 "Root Group/Satellite images/Satellite images multi-sensor - daily/Daily Landsat and Sentinel-2 satellite images"
                             ]
+                        },
+                        {
+                            "type": "wms",
+                            "name": "DEA Surface Reflectance (Landsat and Sentinel-2, OWS)",
+                            "url": "https://ows.dea.ga.gov.au/",
+                            "opacity": 1,
+                            "layers": "s2_ls_combined",
+                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                            "linkedWcsCoverage": "s2_ls_combined",
+                            "chartColor": "white",
+                            "timeFilterPropertyName": "data_available_for_dates",
+                            "leafletUpdateInterval": 750,
+                            "chartType": "momentPoints",
+                            "featureInfoTemplate": {
+                                "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr></table><p><chart id='{{x}}{{y}}{{time}}' title='NBART at {{x}},{{y}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                "formats": {
+                                    "lat": {
+                                        "maximumFractionDigits": 5
+                                    },
+                                    "lon": {
+                                        "maximumFractionDigits": 5
+                                    }
+                                }
+                            },
+                            "tileErrorHandlingOptions": {
+                                "ignoreUnknownTileErrors": true
+                            },
+                            "id": "65KRiP"
                         },
                         {
                             "type": "wms",

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -13,7 +13,7 @@
                     "members": [
                         {
                             "type": "wms",
-                            "name": "DEA Surface Reflectance (Landsat and Sentinel-2)",
+                            "name": "DEA Surface Reflectance (Landsat and Sentinel-2, GSKY)",
                             "url": "https://gsky.nci.org.au/ows/dea",
                             "opacity": 1,
                             "layers": "blend_sentinel2_landsat_nbart_daily",
@@ -25,6 +25,34 @@
                                 "ignoreUnknownTileErrors": true
                             },
                             "id": "DgAS65"
+                        },
+						{
+                            "type": "wms",
+                            "name": "DEA Surface Reflectance (Landsat and Sentinel-2, OWS)",
+                            "url": "https://ows.dev.dea.ga.gov.au/",
+                            "opacity": 1,
+                            "layers": "s2_ls_combined",
+                            "linkedWcsUrl": "https://ows.dev.dea.ga.gov.au/",
+                            "linkedWcsCoverage": "s2_ls_combined",
+                            "chartColor": "white",
+                            "timeFilterPropertyName": "data_available_for_dates",
+                            "leafletUpdateInterval": 750,
+                            "chartType": "momentPoints",
+                            "featureInfoTemplate": {
+                                "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1650</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2220</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>Normalised Difference Vegetation Index</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>Normalised Difference Water Index</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>Modified Normalised Difference Water Index</b></td><td>{{data.0.band_derived.mndwi}}</td></tr><tr><td><b>Normalised Burn Ratio</b></td><td>{{data.0.band_derived.nbr}}</td></tr></table><p><chart id='{{x}}{{y}}{{time}}' title='NBART at {{x}},{{y}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n490,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n840,{{data.0.bands.nbart_nir}}\n1650,{{data.0.bands.nbart_swir1}}\n2220,{{data.0.bands.nbart_swir2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                "formats": {
+                                    "lat": {
+                                        "maximumFractionDigits": 5
+                                    },
+                                    "lon": {
+                                        "maximumFractionDigits": 5
+                                    }
+                                }
+                            },
+                            "tileErrorHandlingOptions": {
+                                "ignoreUnknownTileErrors": true
+                            },
+                            "id": "72HiKx"
                         },
                         {
                             "type": "wms",

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -26,7 +26,7 @@
                             },
                             "id": "DgAS65"
                         },
-						{
+                        {
                             "type": "wms",
                             "name": "DEA Surface Reflectance (Landsat and Sentinel-2, OWS)",
                             "url": "https://ows.dev.dea.ga.gov.au/",


### PR DESCRIPTION
This PR adds the new combined Sentinel-2 and Landsat OWS layer to Terriacube. I've added an "OWS" suffix to this layer, and an "GSKY" suffix to the old layer. 

For now I've left the FeatureInfoTemplate to use the Landsat feature info template, but this currently only includes the RGB Landsat bands that are currently included in the product. I expect this will work better once we add the other bands, but we should remember to have a look at it later on.

![image](https://user-images.githubusercontent.com/17680388/214487151-72919063-b2de-4d09-b9c4-8fb8db81159d.png)
