### PR TITLE
Test out OWS GetMap/GetTile caching in DEA Dev OWS

### DIFF
--- a/dev/services/wms/ows_refactored/ows_reslim_cfg.py
+++ b/dev/services/wms/ows_refactored/ows_reslim_cfg.py
@@ -3,6 +3,10 @@
 
 dataset_cache_rules = [
     {
+        "min_datasets": 1,
+        "max_age": 60 * 60,
+    },
+    {
         "min_datasets": 5,
         "max_age": 60 * 60 * 24,
     },

--- a/dev/services/wms/ows_refactored/ows_root_cfg.py
+++ b/dev/services/wms/ows_refactored/ows_root_cfg.py
@@ -92,6 +92,8 @@ ows_cfg = {
         "s3_aws_zone": "ap-southeast-2",
         "max_width": 512,
         "max_height": 512,
+        # Allow the WMS/WMTS GetCapabilities responses to be cached for 1 hour
+        "caps_cache_maxage": 3600,
     },  # END OF wms SECTION
     "wmts": {
         # Config for WMTS service, for all products/layers
@@ -123,6 +125,8 @@ ows_cfg = {
     "wcs": {
         # Config for WCS service, for all products/coverages
         "default_geographic_CRS": "EPSG:4326",
+        "caps_cache_maxage": 3600,
+        "default_desc_cache_maxage": 3600,
         "formats": {
             "GeoTIFF": {
                 "renderers": {

--- a/prod/services/wms/ows_refactored/ows_reslim_cfg.py
+++ b/prod/services/wms/ows_refactored/ows_reslim_cfg.py
@@ -29,7 +29,8 @@ reslim_standard = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
         "min_zoom_level": 6.9,
-        "dataset_cache_rules": dataset_cache_rules
+        "dataset_cache_rules": dataset_cache_rules,
+        "max_datasets": 24,
     },
     "wcs": common_wcs_limits,
 }
@@ -39,6 +40,7 @@ reslim_for_sentinel2 = {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
         "min_zoom_level": 5.9,
         "dataset_cache_rules": dataset_cache_rules,
+        "max_datasets": 24,
     },
     "wcs": common_wcs_limits,
 }
@@ -48,6 +50,7 @@ reslim_for_lccs = {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
         "min_zoom_level": 7.8,
         "dataset_cache_rules": dataset_cache_rules,
+        "max_datasets": 24,
     },
     "wcs": common_wcs_limits,
 }
@@ -57,6 +60,7 @@ reslim_for_mstp = {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
         "min_zoom_level": 8.1,
         "dataset_cache_rules": dataset_cache_rules,
+        "max_datasets": 24,
     },
     "wcs": common_wcs_limits,
 }


### PR DESCRIPTION
My attempt last week to enable caching failed, see https://github.com/opendatacube/datacube-ows/issues/921

I think I know what went wrong, there was no `max_datasets` set for the layers, and the caching logic decided not to cache anything.

I'm not 100% sure what a reasonable `max_datasets` is, so I've copied the value of 24 from the WCS config.

This change is against DEA Dev OWS, if it's successful, we can make it for Prod too.