### PR TITLE
Fix nodata value in `ga_srtm_dem1sv1_0` product

### DIFF
--- a/products/others/srtm/ga_srtm_dem1sv1_0.odc-product.yaml
+++ b/products/others/srtm/ga_srtm_dem1sv1_0.odc-product.yaml
@@ -18,15 +18,15 @@ measurements:
 - name: dem
   dtype: float32
   units: metre
-  nodata: -3.4028235e+38
+  nodata: -340282346638528859811704183484516925440
 - name: dem_s
   dtype: float32
   units: metre
-  nodata: -3.4028235e+38
+  nodata: -340282346638528859811704183484516925440
 - name: dem_h
   dtype: float32
   units: metre
-  nodata: -3.4028235e+38
+  nodata: -340282346638528859811704183484516925440
 
 storage:
   crs: EPSG:4326


### PR DESCRIPTION
Issue #1348 (https://github.com/opendatacube/datacube-core/issues/1348) discusses issues with the nodata value in the `ga_srtm_dem1sv1_0` SRTM DEM product. It appears that the issue is caused by the nodata value being truncated and losing precision when converted to scientific notation format, which then prevents it from being applied correctly by funcs like `from datacube.utils.masking import mask_invalid_data`. 

This PR attempts to fix this issue by using the full non-truncated nodata string instead of the shorter scientific notation.