### PR TITLE
Minor Sentinel-2 Collection 3 OWS name and description updates

### DIFF
--- a/dev/services/wms/ows_refactored/baseline_satellite_data/landsat_s2_combined/ows_c3_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/landsat_s2_combined/ows_c3_cfg.py
@@ -25,7 +25,7 @@ This product combines:
    * Landsat-5 https://cmi.ga.gov.au/data-products/dea/358/dea-surface-reflectance-landsat-5-tm
    * Landsat-7 https://cmi.ga.gov.au/data-products/dea/475/dea-surface-reflectance-landsat-7-etm
    * Landsat-8 https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-8-oli-tirs
-   * Landsat-9 
+   * Landsat-9
 
 For service status information, see https://status.dea.ga.gov.au""",
     "multi_product": True,

--- a/dev/services/wms/ows_refactored/baseline_satellite_data/landsat_s2_combined/ows_c3_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/landsat_s2_combined/ows_c3_cfg.py
@@ -16,13 +16,16 @@ combined_layer = {
 
 This product takes Sentinel-2 and Landsat imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
 
-Where Sentinel-2 and Landsat data are both available, the higher resolution
-Sentinel-2 data is used.
+Where Sentinel-2 and Landsat data are both available, the higher resolution Sentinel-2 data is used.
 
 This product combines:
 
-   * Sentinel-2A/Sentinel-2B
-   * Landsat-5/Landsat-7/Landsat-8/Landsat-9
+   * Sentinel-2A https://cmi.ga.gov.au/data-products/dea/683/dea-surface-reflectance-sentinel-2a-msi
+   * Sentinel-2B https://cmi.ga.gov.au/data-products/dea/825/dea-surface-reflectance-sentinel-2b-msi
+   * Landsat-5 https://cmi.ga.gov.au/data-products/dea/358/dea-surface-reflectance-landsat-5-tm
+   * Landsat-7 https://cmi.ga.gov.au/data-products/dea/475/dea-surface-reflectance-landsat-7-etm
+   * Landsat-8 https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-8-oli-tirs
+   * Landsat-9 
 
 For service status information, see https://status.dea.ga.gov.au""",
     "multi_product": True,

--- a/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/ows_ard_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/ows_ard_cfg.py
@@ -7,17 +7,22 @@ from ows_refactored.ows_reslim_cfg import reslim_for_sentinel2
 s2b_layer = {
     "name": "ga_s2bm_ard_3",
     "title": "DEA Surface Reflectance (Sentinel-2B MSI)",
-    "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2B MSI)
+    "abstract": """Geoscience Australia Sentinel-2B MSI Analysis Ready Data Collection 3
 
-This product has been corrected to account for variations caused by atmospheric properties, sun position and sensor view angle at time of image capture.
+This product takes Sentinel-2B imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
 
-These corrections have been applied to all satellite imagery in the Sentinel-2 archive. This is undertaken to allow comparison of imagery acquired at different times, in different seasons and in different geographic locations.
+The imagery is captured using the Multispectral Instrument (MSI) sensor aboard Sentinel-2B.
 
-These products also indicate where the imagery has been affected by cloud or cloud shadow, contains missing data or has been affected in other ways. The Surface Reflectance products are useful as a fundamental starting point for any further analysis, and underpin all other optical derived Digital Earth Australia products.
+This product is a single, cohesive Analysis Ready Data (ARD) package, which allows the analysis of surface reflectance data as is, without the need to apply additional corrections.
 
-This is a definitive archive of daily Sentinel-2 data. This is processed using correct ancillary data to provide a more accurate product than the Near Real Time. The Surface Reflectance product has been corrected to account for variations caused by atmospheric properties, sun position and sensor view angle at time of image capture. These corrections have been applied to all satellite imagery in the Sentinel-2 archive. For more information see http://pid.geoscience.gov.au/dataset/ga/129684 The Normalised Difference Chlorophyll Index (NDCI) is based on the method of Mishra & Mishra 2012, and adapted to bands on the Sentinel-2A & B sensors. The index indicates levels of chlorophyll-a (chl-a) concentrations in complex turbid productive waters such as those encountered in many inland water bodies. The index has not been validated in Australian waters, and there are a range of environmental conditions that may have an effect on the accuracy of the derived index values in this test implementation, including: - Influence on the remote sensing signal from nearby land and/or atmospheric effects - Optically shallow water - Cloud cover Mishra, S., Mishra, D.R., 2012. Normalized difference chlorophyll index: A novel model for remote estimation of chlorophyll-a concentration in turbid productive waters. Remote Sensing of Environment, Remote Sensing of Urban Environments 117, 394–406. https://doi.org/10.1016/j.rse.2011.10.016
+It contains two sub-products that provide corrections or attribution information:
 
-https://cmi.ga.gov.au/data-products/dea/190/dea-surface-reflectance-nbart-sentinel-2-msi
+   * DEA Surface Reflectance NBART (Sentinel-2B MSI) https://cmi.ga.gov.au/data-products/dea/824/dea-surface-reflectance-nbart-sentinel-2b-msi
+   * DEA Surface Reflectance OA (Sentinel-2B MSI) https://cmi.ga.gov.au/data-products/dea/823/dea-surface-reflectance-oa-sentinel-2b-msi
+
+The resolution is a 10/20/60 m grid based on the ESA Level 1C archive.
+
+Full product description: https://cmi.ga.gov.au/data-products/dea/825/dea-surface-reflectance-sentinel-2b-msi
 
 For service status information, see https://status.dea.ga.gov.au""",
     "product_name": "ga_s2bm_ard_3",
@@ -51,7 +56,7 @@ For service status information, see https://status.dea.ga.gov.au""",
 s2a_layer = {
     "name": "ga_s2am_ard_3",
     "title": "DEA Surface Reflectance (Sentinel-2A MSI)",
-    "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2A MSI)
+    "abstract": """Geoscience Australia Sentinel-2A MSI Analysis Ready Data Collection 3
 
 This product takes Sentinel-2A imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
 
@@ -59,9 +64,14 @@ The imagery is captured using the Multispectral Instrument (MSI) sensor aboard S
 
 This product is a single, cohesive Analysis Ready Data (ARD) package, which allows the analysis of surface reflectance data as is, without the need to apply additional corrections.
 
+It contains two sub-products that provide corrections or attribution information:
+
+   * DEA Surface Reflectance NBART (Sentinel-2A MSI) https://cmi.ga.gov.au/data-products/dea/671/dea-surface-reflectance-nbart-sentinel-2a-msi
+   * DEA Surface Reflectance OA (Sentinel-2A MSI) https://cmi.ga.gov.au/data-products/dea/677/dea-surface-reflectance-oa-sentinel-2a-msi
+
 The resolution is a 10/20/60 m grid based on the ESA Level 1C archive.
 
-https://cmi.ga.gov.au/data-products/dea/700/dea-surface-reflectance-sentinel-2-msi-collection-3
+Full product description: https://cmi.ga.gov.au/data-products/dea/683/dea-surface-reflectance-sentinel-2a-msi
 
 For service status information, see https://status.dea.ga.gov.au""",
     "product_name": "ga_s2am_ard_3",
@@ -93,19 +103,20 @@ For service status information, see https://status.dea.ga.gov.au""",
 }
 
 combined_layer = {
-    "title": "DEA Surface Reflectance (Sentinel-2 MSI)",
+    "title": "DEA Surface Reflectance (Sentinel-2)",
     "name": "ga_s2m_ard_3",
-    "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2 MSI)
+    "abstract": """Geoscience Australia Sentinel-2 Analysis Ready Data Collection 3
 
-This product takes Sentinel-2A imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
+This product takes Sentinel-2A and Sentinel-2B imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
 
-The imagery is captured using the Multispectral Instrument (MSI) sensor aboard Sentinel-2A.
+The imagery is captured using the Multispectral Instrument (MSI) sensor aboard Sentinel-2A and Sentinel-2B.
 
 This product is a single, cohesive Analysis Ready Data (ARD) package, which allows the analysis of surface reflectance data as is, without the need to apply additional corrections.
 
 The resolution is a 10/20/60 m grid based on the ESA Level 1C archive.
 
-https://cmi.ga.gov.au/data-products/dea/700/dea-surface-reflectance-sentinel-2-msi-collection-3
+Full Sentinel-2A product description: https://cmi.ga.gov.au/data-products/dea/683/dea-surface-reflectance-sentinel-2a-msi
+Full Sentinel-2B product description: https://cmi.ga.gov.au/data-products/dea/825/dea-surface-reflectance-sentinel-2b-msi
 
 For service status information, see https://status.dea.ga.gov.au""",
     "multi_product": True,

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/landsat_s2_combined/ows_c3_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/landsat_s2_combined/ows_c3_cfg.py
@@ -25,7 +25,7 @@ This product combines:
    * Landsat-5 https://cmi.ga.gov.au/data-products/dea/358/dea-surface-reflectance-landsat-5-tm
    * Landsat-7 https://cmi.ga.gov.au/data-products/dea/475/dea-surface-reflectance-landsat-7-etm
    * Landsat-8 https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-8-oli-tirs
-   * Landsat-9 
+   * Landsat-9
 
 For service status information, see https://status.dea.ga.gov.au""",
     "multi_product": True,

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/landsat_s2_combined/ows_c3_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/landsat_s2_combined/ows_c3_cfg.py
@@ -16,13 +16,16 @@ combined_layer = {
 
 This product takes Sentinel-2 and Landsat imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
 
-Where Sentinel-2 and Landsat data are both available, the higher resolution
-Sentinel-2 data is used.
+Where Sentinel-2 and Landsat data are both available, the higher resolution Sentinel-2 data is used.
 
 This product combines:
 
-   * Sentinel-2A/Sentinel-2B
-   * Landsat-5/Landsat-7/Landsat-8/Landsat-9
+   * Sentinel-2A https://cmi.ga.gov.au/data-products/dea/683/dea-surface-reflectance-sentinel-2a-msi
+   * Sentinel-2B https://cmi.ga.gov.au/data-products/dea/825/dea-surface-reflectance-sentinel-2b-msi
+   * Landsat-5 https://cmi.ga.gov.au/data-products/dea/358/dea-surface-reflectance-landsat-5-tm
+   * Landsat-7 https://cmi.ga.gov.au/data-products/dea/475/dea-surface-reflectance-landsat-7-etm
+   * Landsat-8 https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-8-oli-tirs
+   * Landsat-9 
 
 For service status information, see https://status.dea.ga.gov.au""",
     "multi_product": True,

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/sentinel2/ows_ard_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/sentinel2/ows_ard_cfg.py
@@ -7,17 +7,22 @@ from ows_refactored.ows_reslim_cfg import reslim_for_sentinel2
 s2b_layer = {
     "name": "ga_s2bm_ard_3",
     "title": "DEA Surface Reflectance (Sentinel-2B MSI)",
-    "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2B MSI)
+    "abstract": """Geoscience Australia Sentinel-2B MSI Analysis Ready Data Collection 3
 
-This product has been corrected to account for variations caused by atmospheric properties, sun position and sensor view angle at time of image capture.
+This product takes Sentinel-2B imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
 
-These corrections have been applied to all satellite imagery in the Sentinel-2 archive. This is undertaken to allow comparison of imagery acquired at different times, in different seasons and in different geographic locations.
+The imagery is captured using the Multispectral Instrument (MSI) sensor aboard Sentinel-2B.
 
-These products also indicate where the imagery has been affected by cloud or cloud shadow, contains missing data or has been affected in other ways. The Surface Reflectance products are useful as a fundamental starting point for any further analysis, and underpin all other optical derived Digital Earth Australia products.
+This product is a single, cohesive Analysis Ready Data (ARD) package, which allows the analysis of surface reflectance data as is, without the need to apply additional corrections.
 
-This is a definitive archive of daily Sentinel-2 data. This is processed using correct ancillary data to provide a more accurate product than the Near Real Time. The Surface Reflectance product has been corrected to account for variations caused by atmospheric properties, sun position and sensor view angle at time of image capture. These corrections have been applied to all satellite imagery in the Sentinel-2 archive. For more information see http://pid.geoscience.gov.au/dataset/ga/129684 The Normalised Difference Chlorophyll Index (NDCI) is based on the method of Mishra & Mishra 2012, and adapted to bands on the Sentinel-2A & B sensors. The index indicates levels of chlorophyll-a (chl-a) concentrations in complex turbid productive waters such as those encountered in many inland water bodies. The index has not been validated in Australian waters, and there are a range of environmental conditions that may have an effect on the accuracy of the derived index values in this test implementation, including: - Influence on the remote sensing signal from nearby land and/or atmospheric effects - Optically shallow water - Cloud cover Mishra, S., Mishra, D.R., 2012. Normalized difference chlorophyll index: A novel model for remote estimation of chlorophyll-a concentration in turbid productive waters. Remote Sensing of Environment, Remote Sensing of Urban Environments 117, 394–406. https://doi.org/10.1016/j.rse.2011.10.016
+It contains two sub-products that provide corrections or attribution information:
 
-https://cmi.ga.gov.au/data-products/dea/190/dea-surface-reflectance-nbart-sentinel-2-msi
+   * DEA Surface Reflectance NBART (Sentinel-2B MSI) https://cmi.ga.gov.au/data-products/dea/824/dea-surface-reflectance-nbart-sentinel-2b-msi
+   * DEA Surface Reflectance OA (Sentinel-2B MSI) https://cmi.ga.gov.au/data-products/dea/823/dea-surface-reflectance-oa-sentinel-2b-msi
+
+The resolution is a 10/20/60 m grid based on the ESA Level 1C archive.
+
+Full product description: https://cmi.ga.gov.au/data-products/dea/825/dea-surface-reflectance-sentinel-2b-msi
 
 For service status information, see https://status.dea.ga.gov.au""",
     "product_name": "ga_s2bm_ard_3",
@@ -51,7 +56,7 @@ For service status information, see https://status.dea.ga.gov.au""",
 s2a_layer = {
     "name": "ga_s2am_ard_3",
     "title": "DEA Surface Reflectance (Sentinel-2A MSI)",
-    "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2A MSI)
+    "abstract": """Geoscience Australia Sentinel-2A MSI Analysis Ready Data Collection 3
 
 This product takes Sentinel-2A imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
 
@@ -59,9 +64,14 @@ The imagery is captured using the Multispectral Instrument (MSI) sensor aboard S
 
 This product is a single, cohesive Analysis Ready Data (ARD) package, which allows the analysis of surface reflectance data as is, without the need to apply additional corrections.
 
+It contains two sub-products that provide corrections or attribution information:
+
+   * DEA Surface Reflectance NBART (Sentinel-2A MSI) https://cmi.ga.gov.au/data-products/dea/671/dea-surface-reflectance-nbart-sentinel-2a-msi
+   * DEA Surface Reflectance OA (Sentinel-2A MSI) https://cmi.ga.gov.au/data-products/dea/677/dea-surface-reflectance-oa-sentinel-2a-msi
+
 The resolution is a 10/20/60 m grid based on the ESA Level 1C archive.
 
-https://cmi.ga.gov.au/data-products/dea/700/dea-surface-reflectance-sentinel-2-msi-collection-3
+Full product description: https://cmi.ga.gov.au/data-products/dea/683/dea-surface-reflectance-sentinel-2a-msi
 
 For service status information, see https://status.dea.ga.gov.au""",
     "product_name": "ga_s2am_ard_3",
@@ -93,19 +103,20 @@ For service status information, see https://status.dea.ga.gov.au""",
 }
 
 combined_layer = {
-    "title": "DEA Surface Reflectance (Sentinel-2 MSI)",
+    "title": "DEA Surface Reflectance (Sentinel-2)",
     "name": "ga_s2m_ard_3",
-    "abstract": """Sentinel-2 Multispectral Instrument - Nadir BRDF Adjusted Reflectance + Terrain Illumination Correction (Sentinel-2 MSI)
+    "abstract": """Geoscience Australia Sentinel-2 Analysis Ready Data Collection 3
 
-This product takes Sentinel-2A imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
+This product takes Sentinel-2A and Sentinel-2B imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
 
-The imagery is captured using the Multispectral Instrument (MSI) sensor aboard Sentinel-2A.
+The imagery is captured using the Multispectral Instrument (MSI) sensor aboard Sentinel-2A and Sentinel-2B.
 
 This product is a single, cohesive Analysis Ready Data (ARD) package, which allows the analysis of surface reflectance data as is, without the need to apply additional corrections.
 
 The resolution is a 10/20/60 m grid based on the ESA Level 1C archive.
 
-https://cmi.ga.gov.au/data-products/dea/700/dea-surface-reflectance-sentinel-2-msi-collection-3
+Full Sentinel-2A product description: https://cmi.ga.gov.au/data-products/dea/683/dea-surface-reflectance-sentinel-2a-msi
+Full Sentinel-2B product description: https://cmi.ga.gov.au/data-products/dea/825/dea-surface-reflectance-sentinel-2b-msi
 
 For service status information, see https://status.dea.ga.gov.au""",
     "multi_product": True,


### PR DESCRIPTION
I noticed that the current Sentinel-2 OWS layers haven't been updated to their Collection 3 descriptions. This PR updates these layers to use the convention agreed upon in 3/09/2021:
![image](https://user-images.githubusercontent.com/17680388/215687786-82b5d615-ef75-4bb2-968c-dabcbe456287.png)

The new content is taken directly from CMI as per the convention, and I've updated some of the CMI URLs to point to the new product descriptions instead of the old Sentinel-2 Collection 1 data. 

Also linked to the relevant CMI listings on the Combined layers so that users can access more info about those products. 