### PR TITLE
Line up LS8 GM cyear product with ARD _nbart aliases

### DIFF
--- a/products/baseline_satellite_data/geomedian-au/ga_ls8c_nbart_gm_cyear_3.odc-product.yaml
+++ b/products/baseline_satellite_data/geomedian-au/ga_ls8c_nbart_gm_cyear_3.odc-product.yaml
@@ -11,30 +11,40 @@ metadata:
     name: ga_ls8c_nbart_gm_cyear_3
 
 measurements:
-  - name: blue
+  - name: nbart_blue
     dtype: int16
     nodata: -999
     units: '1'
-  - name: green
+    aliases:
+    - blue
+  - name: nbart_green
     dtype: int16
     nodata: -999
     units: '1'
-  - name: red
+    aliases:
+    - green
+  - name: nbart_red
     dtype: int16
     nodata: -999
     units: '1'
-  - name: nir
+  - name: nbart_nir
     dtype: int16
     nodata: -999
     units: '1'
-  - name: swir1
+    aliases:
+    - nir
+  - name: nbart_swir1
     dtype: int16
     nodata: -999
     units: '1'
-  - name: swir2
+    aliases:
+    - swir1
+  - name: nbart_swir2
     dtype: int16
     nodata: -999
     units: '1'
+    aliases:
+    - swir2
   - name: sdev
     dtype: float32
     nodata: .nan


### PR DESCRIPTION
LS8 ARD product has been [updated to use `_nbart` prefixes for its fields](https://github.com/GeoscienceAustralia/dea-config/blob/db80d7bf15961d51a7941929f979a696d2a241ac/products/baseline_satellite_data/c3/ga_ls8c_ard_c2_3.odc-product.yaml#L91-L97), as well as adding the previous field name as an alias. [Statistician has been updated to reflect this](https://github.com/opendatacube/odc-stats/commit/5479f91ce3fc81d013e1321c75f2a33ea81a54bc), and for the summary product output to match this arrangement.

Add aliases to the geomedian cyear product as well.