### PR TITLE
Remove "nodata" flag from FC WOFS masking.

### DIFF
--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -15,10 +15,11 @@ c3_fc_pq_mask = [
             "high_slope": False,
             "cloud_shadow": False,
             "cloud": False,
-# "nodata": False,   # Do NOT mask on nodata.  If masking data is unavailable
-                     # (e.g. because WOFS processing has stalled) then masking
-                     # on nodata results in ALL FC data being masked - which
-                     # is the opposite of what we want in this case.
+            # "nodata": False,   
+            # Do NOT mask on nodata.  If masking data is unavailable
+            # (e.g. because WOFS processing has stalled) then masking
+            # on nodata results in ALL FC data being masked - which
+            # is the opposite of what we want in this case.
         },
     },
     {

--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -15,7 +15,7 @@ c3_fc_pq_mask = [
             "high_slope": False,
             "cloud_shadow": False,
             "cloud": False,
-            # "nodata": False,   
+            # "nodata": False,
             # Do NOT mask on nodata.  If masking data is unavailable
             # (e.g. because WOFS processing has stalled) then masking
             # on nodata results in ALL FC data being masked - which

--- a/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -15,7 +15,10 @@ c3_fc_pq_mask = [
             "high_slope": False,
             "cloud_shadow": False,
             "cloud": False,
-            "nodata": False,
+# "nodata": False,   # Do NOT mask on nodata.  If masking data is unavailable
+                     # (e.g. because WOFS processing has stalled) then masking
+                     # on nodata results in ALL FC data being masked - which
+                     # is the opposite of what we want in this case.
         },
     },
     {

--- a/prod/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/prod/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -15,10 +15,11 @@ c3_fc_pq_mask = [
             "high_slope": False,
             "cloud_shadow": False,
             "cloud": False,
-# "nodata": False,   # Do NOT mask on nodata.  If masking data is unavailable
-                     # (e.g. because WOFS processing has stalled) then masking
-                     # on nodata results in ALL FC data being masked - which
-                     # is the opposite of what we want in this case.
+            # "nodata": False,   
+            # Do NOT mask on nodata.  If masking data is unavailable
+            # (e.g. because WOFS processing has stalled) then masking
+            # on nodata results in ALL FC data being masked - which
+            # is the opposite of what we want in this case.
         },
     },
     {

--- a/prod/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/prod/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -15,7 +15,7 @@ c3_fc_pq_mask = [
             "high_slope": False,
             "cloud_shadow": False,
             "cloud": False,
-            # "nodata": False,   
+            # "nodata": False,
             # Do NOT mask on nodata.  If masking data is unavailable
             # (e.g. because WOFS processing has stalled) then masking
             # on nodata results in ALL FC data being masked - which

--- a/prod/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
+++ b/prod/services/wms/ows_refactored/land_and_vegetation/fc/style_fc_cfg.py
@@ -15,7 +15,10 @@ c3_fc_pq_mask = [
             "high_slope": False,
             "cloud_shadow": False,
             "cloud": False,
-            "nodata": False,
+# "nodata": False,   # Do NOT mask on nodata.  If masking data is unavailable
+                     # (e.g. because WOFS processing has stalled) then masking
+                     # on nodata results in ALL FC data being masked - which
+                     # is the opposite of what we want in this case.
         },
     },
     {


### PR DESCRIPTION
Daily Fractional Cover was not being displayed when the corresponding WOFS daily data was not available for masking.

This was reported as an issue against OWS: https://github.com/opendatacube/datacube-ows/issues/925

But it turns out to be an over-zealous masking rule here.

As discussed in the comments, masking by a masking product's "nodata" flag is almost certainly never the right thing to do.