### PR TITLE
Use year format for Tasseled Cap Indices Calendar Year

### DIFF
--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -2659,6 +2659,7 @@
                                     "tileErrorHandlingOptions": {
                                         "ignoreUnknownTileErrors": true
                                     },
+                                    "dateFormat": "'Year: 'yyyy",
                                     "id": "hbmzp5",
                                     "shareKeys": [
                                         "Root Group/Surface Water/DEA Wetness Percentiles (Landsat)/Tasseled Cap Indices Percentiles"

--- a/prod/terria/dea-maps-v8.json
+++ b/prod/terria/dea-maps-v8.json
@@ -831,6 +831,7 @@
                                     "tileErrorHandlingOptions": {
                                         "ignoreUnknownTileErrors": true
                                     },
+                                    "dateFormat": "'Year: 'yyyy",
                                     "id": "hbmzp5",
                                     "shareKeys": [
                                         "Root Group/Surface Water/DEA Wetness Percentiles (Landsat)/Tasseled Cap Indices Percentiles"


### PR DESCRIPTION
The DEA Tasseled Cap Indices Percentiles Calendar Year (Landsat) product currently uses full date strings for each timestep:

![image](https://user-images.githubusercontent.com/17680388/225168001-f6649283-a2d2-48a8-8ec8-893d82c7fde3.png)

This PR formats these dates as years for consistency with all our other annual products:

![image](https://user-images.githubusercontent.com/17680388/225168163-162e377a-6f55-4b02-851a-68e902aa8aca.png)
