### PR TITLE
Add 48 km and 32 km coastal grids to dev Terria

### DIFF
--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -1602,7 +1602,7 @@
                                     "featureInfoTemplate": {
                                         "template": "<div style='width:480px'><h1 style='font-weight:normal'>ID: <b>{{id}}</b></br>Type: <b>{{type}}</b></h1></div>"
                                     }
-								},
+                                },
                                 {
                                     "type": "geojson",
                                     "name": "DEA Intertidal 32 km coastal grid (Collection 3)",

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -1599,7 +1599,7 @@
                                     "name": "DEA Coastlines 48 km coastal grid (Collection 3)",
                                     "url": "https://data.dea.ga.gov.au/derivative/dea_coastlines/supplementary/albers_grids/ga_summary_grid_c3_48km_coastal_clipped.geojson",
                                     "id": "GHt78c",
-									"featureInfoTemplate": {
+                                    "featureInfoTemplate": {
                                         "template": "<div style='width:480px'><h1 style='font-weight:normal'>ID: <b>{{id}}</b></br>Type: <b>{{type}}</b></h1></div>"
                                     }
 								},
@@ -1608,7 +1608,7 @@
                                     "name": "DEA Intertidal 32 km coastal grid (Collection 3)",
                                     "url": "https://data.dea.ga.gov.au/derivative/dea_coastlines/supplementary/albers_grids/ga_summary_grid_c3_32km_coastal_clipped.geojson",
                                     "id": "TY67mT",
-									"featureInfoTemplate": {
+                                    "featureInfoTemplate": {
                                         "template": "<div style='width:480px'><h1 style='font-weight:normal'>ID: <b>{{id}}</b></br>Type: <b>{{type}}</b></h1></div>"
                                     }
                                 }

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -1593,6 +1593,18 @@
                                     "shareKeys": [
                                         "Root Group/DEA Shapes/DEA Albers Tiles grid"
                                     ]
+                                },
+                                {
+                                    "type": "geojson",
+                                    "name": "DEA Coastlines 48 km coastal grid (Collection 3)",
+                                    "url": "https://data.dea.ga.gov.au/derivative/dea_coastlines/supplementary/albers_grids/ga_summary_grid_c3_48km_coastal_clipped.geojson",
+                                    "id": "GHt78c"
+                                },
+                                {
+                                    "type": "geojson",
+                                    "name": "DEA Intertidal 32 km coastal grid (Collection 3)",
+                                    "url": "https://data.dea.ga.gov.au/derivative/dea_coastlines/supplementary/albers_grids/ga_summary_grid_c3_32km_coastal_clipped.geojson",
+                                    "id": "TY67mT"
                                 }
                             ]
                         },

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -1598,13 +1598,19 @@
                                     "type": "geojson",
                                     "name": "DEA Coastlines 48 km coastal grid (Collection 3)",
                                     "url": "https://data.dea.ga.gov.au/derivative/dea_coastlines/supplementary/albers_grids/ga_summary_grid_c3_48km_coastal_clipped.geojson",
-                                    "id": "GHt78c"
-                                },
+                                    "id": "GHt78c",
+									"featureInfoTemplate": {
+                                        "template": "<div style='width:480px'><h1 style='font-weight:normal'>ID: <b>{{id}}</b></br>Type: <b>{{type}}</b></h1></div>"
+                                    }
+								},
                                 {
                                     "type": "geojson",
                                     "name": "DEA Intertidal 32 km coastal grid (Collection 3)",
                                     "url": "https://data.dea.ga.gov.au/derivative/dea_coastlines/supplementary/albers_grids/ga_summary_grid_c3_32km_coastal_clipped.geojson",
-                                    "id": "TY67mT"
+                                    "id": "TY67mT",
+									"featureInfoTemplate": {
+                                        "template": "<div style='width:480px'><h1 style='font-weight:normal'>ID: <b>{{id}}</b></br>Type: <b>{{type}}</b></h1></div>"
+                                    }
                                 }
                             ]
                         },


### PR DESCRIPTION
I often find myself wanting to quickly inspect the 48 km and 32 km coastal grids for DEA Coastlines or DEA Intertidal (e.g. to choose what tile to run). This adds those grids to dev Terria so it's easier to inspect them using Terria! 😃 

Should appear under "DEA Development > Other > DEA Shapes"

![image](https://user-images.githubusercontent.com/17680388/227133957-5d33aad9-d251-42ad-94c4-3c8b39052da9.png)
