### PR TITLE
add ls9 web services to prod

### DIFF
--- a/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
@@ -50,7 +50,7 @@ It contains three sub-products that provide corrections or attribution informati
 DEA Surface Reflectance NBAR (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/402/dea-surface-reflectance-nbar-landsat-9-oli-tirs
 DEA Surface Reflectance NBART (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/400/dea-surface-reflectance-nbart-landsat-9-oli-tirs
 DEA Surface Reflectance OA (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/404/dea-surface-reflectance-oa-landsat-9-oli-tirs
-The resolution is a 30 m grid based on the USGS Landsat Collection 1 archive.
+The resolution is a 30 m grid based on the USGS Landsat Collection 2 archive.
 
 https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-9-oli-tirs
 

--- a/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
@@ -101,7 +101,7 @@ It contains three sub-products that provide corrections or attribution informati
 DEA Surface Reflectance NBAR (Landsat 8 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/402/dea-surface-reflectance-nbar-landsat-8-oli-tirs
 DEA Surface Reflectance NBART (Landsat 8 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/400/dea-surface-reflectance-nbart-landsat-8-oli-tirs
 DEA Surface Reflectance OA (Landsat 8 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/404/dea-surface-reflectance-oa-landsat-8-oli-tirs
-The resolution is a 30 m grid based on the USGS Landsat Collection 1 archive.
+The resolution is a 30 m grid based on the USGS Landsat Collection 1 and 2 archive.
 
 https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-8-oli-tirs
 
@@ -150,7 +150,7 @@ It contains three sub-products that provide corrections or attribution informati
 DEA Surface Reflectance NBAR (Landsat 7 ETM+) https://cmi.ga.gov.au/data-products/dea/476/dea-surface-reflectance-nbar-landsat-7-etm
 DEA Surface Reflectance NBART (Landsat 7 ETM+) https://cmi.ga.gov.au/data-products/dea/399/dea-surface-reflectance-nbart-landsat-7-etm
 DEA Surface Reflectance OA (Landsat 7 ETM+) https://cmi.ga.gov.au/data-products/dea/478/dea-surface-reflectance-oa-landsat-7-etm
-The resolution is a 30 m grid based on the USGS Landsat Collection 1 archive.
+The resolution is a 30 m grid based on the USGS Landsat Collection 1 and 2 archive.
 
 https://cmi.ga.gov.au/data-products/dea/475/dea-surface-reflectance-landsat-7-etm
 

--- a/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
@@ -39,7 +39,7 @@ For service status information, see https://status.dea.ga.gov.au""",
             "title": "DEA Surface Reflectance (Landsat 9 OLI-TIRS)",
             "abstract": """Geoscience Australia Landsat 9 OLI-TIRS Analysis Ready Data Collection 3
 
-This product takes Landsat 8 imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
+This product takes Landsat 9 imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
 
 The imagery is captured using the Operational Land Imager (OLI) and Thermal Infra-Red Scanner (TIRS) sensors aboard Landsat 9.
 

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -2205,39 +2205,40 @@
                                 "Root Group/Satellite images/Satellite images 25m - annual"
                             ]
                         },
-                            "type": "wms",
-                            "name": "DEA Surface Reflectance (Landsat 9 OLI-TIRS)",
-                            "url": "https://ows.dea.ga.gov.au/",
-                            "opacity": 1,
-                            "layers": "ga_ls9c_ard_3",
-                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                            "linkedWcsCoverage": "ga_ls9c_ard_3",
-                            "chartColor": "white",
-                            "timeFilterPropertyName": "data_available_for_dates",
-                            "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
-                            "leafletUpdateInterval": 750,
-                            "chartType": "momentPoints",
-                            "featureInfoTemplate": {
-                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n870,{{data.0.bands.nbart_nir}}\n1610,{{data.0.bands.nbart_swir_1}}\n2200,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
-                                "formats": {
-                                    "lat": {
-                                        "maximumFractionDigits": 5
-                                    },
-                                    "lon": {
-                                        "maximumFractionDigits": 5
-                                    }
-                                }
-                            },
-                            "tileErrorHandlingOptions": {
-                                "ignoreUnknownTileErrors": true
-                            },
-                            "id": "584D9e"
-                        },
                         {
                             "id": "aN8xKz",
                             "type": "group",
                             "name": "DEA Surface Reflectance (Landsat)",
                             "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Surface Reflectance (Landsat 9 OLI-TIRS)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ga_ls9c_ard_3",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ga_ls9c_ard_3",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n870,{{data.0.bands.nbart_nir}}\n1610,{{data.0.bands.nbart_swir_1}}\n2200,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "754D3e"
+                                },
                                 {
                                     "type": "wms",
                                     "name": "DEA Surface Reflectance (Landsat 8 OLI-TIRS)",

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -2205,6 +2205,34 @@
                                 "Root Group/Satellite images/Satellite images 25m - annual"
                             ]
                         },
+                            "type": "wms",
+                            "name": "DEA Surface Reflectance (Landsat 9 OLI-TIRS)",
+                            "url": "https://ows.dea.ga.gov.au/",
+                            "opacity": 1,
+                            "layers": "ga_ls9c_ard_3",
+                            "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                            "linkedWcsCoverage": "ga_ls9c_ard_3",
+                            "chartColor": "white",
+                            "timeFilterPropertyName": "data_available_for_dates",
+                            "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                            "leafletUpdateInterval": 750,
+                            "chartType": "momentPoints",
+                            "featureInfoTemplate": {
+                                "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n870,{{data.0.bands.nbart_nir}}\n1610,{{data.0.bands.nbart_swir_1}}\n2200,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                "formats": {
+                                    "lat": {
+                                        "maximumFractionDigits": 5
+                                    },
+                                    "lon": {
+                                        "maximumFractionDigits": 5
+                                    }
+                                }
+                            },
+                            "tileErrorHandlingOptions": {
+                                "ignoreUnknownTileErrors": true
+                            },
+                            "id": "584D9e"
+                        },
                         {
                             "id": "aN8xKz",
                             "type": "group",

--- a/prod/services/wms/inventory.json
+++ b/prod/services/wms/inventory.json
@@ -1,5 +1,5 @@
 {
-    "total_layers_count": 63,
+    "total_layers_count": 64,
     "layers": [
          {
             "layer": "s2_ls_combined",
@@ -33,7 +33,8 @@
             "product": [
                 "ga_ls5t_ard_3",
                 "ga_ls7e_ard_3",
-                "ga_ls8c_ard_3"
+                "ga_ls8c_ard_3",
+                "ga_ls9c_ard_3"
             ],
             "styles_count": 13,
             "styles_list": [
@@ -219,6 +220,31 @@
                 "tmad_rgb_std",
                 "tmad_rgb_sens",
                 "count"
+            ]
+        },
+        {
+            "layer": "ga_ls9c_ard_3",
+            "product": [
+                "ga_ls9c_ard_3"
+            ],
+            "styles_count": 16,
+            "styles_list": [
+                "true_colour",
+                "true_colour_pan",
+                "false_colour",
+                "ndvi",
+                "ndwi",
+                "mndwi",
+                "nbr",
+                "aerosol",
+                "blue",
+                "green",
+                "red",
+                "nir",
+                "swir1",
+                "swir2",
+                "panchromatic",
+                "fmask"
             ]
         },
         {

--- a/prod/services/wms/inventory.json
+++ b/prod/services/wms/inventory.json
@@ -227,10 +227,9 @@
             "product": [
                 "ga_ls9c_ard_3"
             ],
-            "styles_count": 16,
+            "styles_count": 15,
             "styles_list": [
                 "true_colour",
-                "true_colour_pan",
                 "false_colour",
                 "ndvi",
                 "ndwi",

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
@@ -50,7 +50,7 @@ It contains three sub-products that provide corrections or attribution informati
 DEA Surface Reflectance NBAR (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/402/dea-surface-reflectance-nbar-landsat-9-oli-tirs
 DEA Surface Reflectance NBART (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/400/dea-surface-reflectance-nbart-landsat-9-oli-tirs
 DEA Surface Reflectance OA (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/404/dea-surface-reflectance-oa-landsat-9-oli-tirs
-The resolution is a 30 m grid based on the USGS Landsat Collection 1 archive.
+The resolution is a 30 m grid based on the USGS Landsat Collection 2 archive.
 
 https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-9-oli-tirs
 

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
@@ -101,7 +101,7 @@ It contains three sub-products that provide corrections or attribution informati
 DEA Surface Reflectance NBAR (Landsat 8 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/402/dea-surface-reflectance-nbar-landsat-8-oli-tirs
 DEA Surface Reflectance NBART (Landsat 8 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/400/dea-surface-reflectance-nbart-landsat-8-oli-tirs
 DEA Surface Reflectance OA (Landsat 8 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/404/dea-surface-reflectance-oa-landsat-8-oli-tirs
-The resolution is a 30 m grid based on the USGS Landsat Collection 1 archive.
+The resolution is a 30 m grid based on the USGS Landsat Collection 1 and 2 archive.
 
 https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-8-oli-tirs
 
@@ -150,7 +150,7 @@ It contains three sub-products that provide corrections or attribution informati
 DEA Surface Reflectance NBAR (Landsat 7 ETM+) https://cmi.ga.gov.au/data-products/dea/476/dea-surface-reflectance-nbar-landsat-7-etm
 DEA Surface Reflectance NBART (Landsat 7 ETM+) https://cmi.ga.gov.au/data-products/dea/399/dea-surface-reflectance-nbart-landsat-7-etm
 DEA Surface Reflectance OA (Landsat 7 ETM+) https://cmi.ga.gov.au/data-products/dea/478/dea-surface-reflectance-oa-landsat-7-etm
-The resolution is a 30 m grid based on the USGS Landsat Collection 1 archive.
+The resolution is a 30 m grid based on the USGS Landsat Collection 1 and 2 archive.
 
 https://cmi.ga.gov.au/data-products/dea/475/dea-surface-reflectance-landsat-7-etm
 

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
@@ -257,6 +257,7 @@ For service status information, see https://status.dea.ga.gov.au""",
         "ga_ls5t_ard_3",
         "ga_ls7e_ard_3",
         "ga_ls8c_ard_3",
+        "ga_ls9c_ard_3",
 
     ],
     "bands": bands_c3_ls_common,

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
@@ -36,6 +36,57 @@ layers = {
 For service status information, see https://status.dea.ga.gov.au""",
     "layers": [
         {
+            "title": "DEA Surface Reflectance (Landsat 9 OLI-TIRS)",
+            "abstract": """Geoscience Australia Landsat 9 OLI-TIRS Analysis Ready Data Collection 3
+
+This product takes Landsat 9 imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
+
+The imagery is captured using the Operational Land Imager (OLI) and Thermal Infra-Red Scanner (TIRS) sensors aboard Landsat 9.
+
+This product is a single, cohesive Analysis Ready Data (ARD) package, which allows you to analyse surface reflectance data as is, without the need to apply additional corrections.
+
+It contains three sub-products that provide corrections or attribution information:
+
+DEA Surface Reflectance NBAR (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/402/dea-surface-reflectance-nbar-landsat-9-oli-tirs
+DEA Surface Reflectance NBART (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/400/dea-surface-reflectance-nbart-landsat-9-oli-tirs
+DEA Surface Reflectance OA (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/404/dea-surface-reflectance-oa-landsat-9-oli-tirs
+The resolution is a 30 m grid based on the USGS Landsat Collection 1 archive.
+
+https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-9-oli-tirs
+
+For service status information, see https://status.dea.ga.gov.au""",
+            # The WMS name for the layer
+            "name": "ga_ls9c_ard_3",
+            # The Datacube name for the associated data product
+            "product_name": "ga_ls9c_ard_3",
+            "dynamic": True,
+            "bands": bands_c3_ls_8,
+            "resource_limits": reslim_standard,
+            "native_crs": "EPSG:3577",
+            "native_resolution": [25, -25],
+            "image_processing": {
+                "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
+                "always_fetch_bands": [],
+                "manual_merge": False,
+            },
+            "flags": [
+                # flags is now a list of flag band definitions - NOT a dictionary with identifiers
+                {
+                    "band": "oa_fmask",
+                    "product": "ga_ls9c_ard_3",
+                    "ignore_time": False,
+                    "ignore_info_flags": [],
+                },
+                {
+                    "band": "land",
+                    "product": "geodata_coast_100k",
+                    "ignore_time": True,
+                    "ignore_info_flags": []
+                },
+            ],
+            "styling": {"default_style": "true_colour", "styles": styles_c3_ls_8},
+        },
+        {
             "title": "DEA Surface Reflectance (Landsat 8 OLI-TIRS)",
             "abstract": """Geoscience Australia Landsat 8 OLI-TIRS Analysis Ready Data Collection 3
 
@@ -195,6 +246,7 @@ combined_layer = {
 This product takes Landsat imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
 
 This product combines:
+Landsat 9 imagery https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-9-oli-tirs,
 Landsat 8 imagery https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-8-oli-tirs,
 Landsat 7 imagery https://cmi.ga.gov.au/data-products/dea/475/dea-surface-reflectance-landsat-7-etm and
 Landsat 5 Imagery https://cmi.ga.gov.au/data-products/dea/358/dea-surface-reflectance-landsat-5-tm
@@ -205,6 +257,7 @@ For service status information, see https://status.dea.ga.gov.au""",
         "ga_ls5t_ard_3",
         "ga_ls7e_ard_3",
         "ga_ls8c_ard_3",
+
     ],
     "bands": bands_c3_ls_common,
     "resource_limits": reslim_standard,
@@ -223,6 +276,7 @@ For service status information, see https://status.dea.ga.gov.au""",
                 "ga_ls5t_ard_3",
                 "ga_ls7e_ard_3",
                 "ga_ls8c_ard_3",
+                "ga_ls9c_ard_3",
             ],
             "ignore_time": False,
             "ignore_info_flags": [],

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py
@@ -47,12 +47,12 @@ This product is a single, cohesive Analysis Ready Data (ARD) package, which allo
 
 It contains three sub-products that provide corrections or attribution information:
 
-DEA Surface Reflectance NBAR (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/402/dea-surface-reflectance-nbar-landsat-9-oli-tirs
-DEA Surface Reflectance NBART (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/400/dea-surface-reflectance-nbart-landsat-9-oli-tirs
-DEA Surface Reflectance OA (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/404/dea-surface-reflectance-oa-landsat-9-oli-tirs
+DEA Surface Reflectance NBAR (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/819/dea-surface-reflectance-nbar-landsat-9-oli-tirs
+DEA Surface Reflectance NBART (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/817/dea-surface-reflectance-nbart-landsat-9-oli-tirs
+DEA Surface Reflectance OA (Landsat 9 OLI-TIRS) https://cmi.ga.gov.au/data-products/dea/818/dea-surface-reflectance-oa-landsat-9-oli-tirs
 The resolution is a 30 m grid based on the USGS Landsat Collection 2 archive.
 
-https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-9-oli-tirs
+https://cmi.ga.gov.au/data-products/dea/816/dea-surface-reflectance-landsat-9
 
 For service status information, see https://status.dea.ga.gov.au""",
             # The WMS name for the layer
@@ -246,7 +246,7 @@ combined_layer = {
 This product takes Landsat imagery captured over the Australian continent and corrects for inconsistencies across land and coastal fringes. The result is accurate and standardised surface reflectance data, which is instrumental in identifying and quantifying environmental change.
 
 This product combines:
-Landsat 9 imagery https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-9-oli-tirs,
+Landsat 9 imagery https://cmi.ga.gov.au/data-products/dea/816/dea-surface-reflectance-landsat-9,
 Landsat 8 imagery https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-8-oli-tirs,
 Landsat 7 imagery https://cmi.ga.gov.au/data-products/dea/475/dea-surface-reflectance-landsat-7-etm and
 Landsat 5 Imagery https://cmi.ga.gov.au/data-products/dea/358/dea-surface-reflectance-landsat-5-tm

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/landsat_s2_combined/ows_c3_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/landsat_s2_combined/ows_c3_cfg.py
@@ -29,7 +29,7 @@ This product combines:
    * Landsat-5 https://cmi.ga.gov.au/data-products/dea/358/dea-surface-reflectance-landsat-5-tm
    * Landsat-7 https://cmi.ga.gov.au/data-products/dea/475/dea-surface-reflectance-landsat-7-etm
    * Landsat-8 https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-8-oli-tirs
-   * Landsat-9
+   * Landsat-9 https://cmi.ga.gov.au/data-products/dea/365/dea-surface-reflectance-landsat-9-oli-tirs
 
 For service status information, see https://status.dea.ga.gov.au""",
     "multi_product": True,

--- a/prod/terria/dea-maps-v8.json
+++ b/prod/terria/dea-maps-v8.json
@@ -198,10 +198,10 @@
                                 {
                                     "type": "wms",
                                     "name": "DEA Surface Reflectance (Landsat 9 OLI-TIRS)",
-                                    "url": "https://ows.dev.dea.ga.gov.au/",
+                                    "url": "https://ows.dea.ga.gov.au/",
                                     "opacity": 1,
                                     "layers": "ga_ls9c_ard_3",
-                                    "linkedWcsUrl": "https://ows.dev.dea.ga.gov.au/",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
                                     "linkedWcsCoverage": "ga_ls9c_ard_3",
                                     "chartColor": "white",
                                     "timeFilterPropertyName": "data_available_for_dates",

--- a/prod/terria/dea-maps-v8.json
+++ b/prod/terria/dea-maps-v8.json
@@ -197,6 +197,35 @@
                             "members": [
                                 {
                                     "type": "wms",
+                                    "name": "DEA Surface Reflectance (Landsat 9 OLI-TIRS)",
+                                    "url": "https://ows.dev.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ga_ls9c_ard_3",
+                                    "linkedWcsUrl": "https://ows.dev.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ga_ls9c_ard_3",
+                                    "chartColor": "white",
+                                    "timeFilterPropertyName": "data_available_for_dates",
+                                    "availableDiffStyles": ["ndvi", "ndwi", "mndwi", "nbr"],
+                                    "leafletUpdateInterval": 750,
+                                    "chartType": "momentPoints",
+                                    "featureInfoTemplate": {
+                                        "template": "<table>  <tr><td><b>Time</b></td><td>{{data.0.time}}</td></tr>  <tr><td><b>Blue - 480</b></td><td>{{data.0.bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{data.0.bands.nbart_green}}</td></tr>  <tr><td><b>Red - 660</b></td><td>{{data.0.bands.nbart_red}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 870</b></td><td>{{data.0.bands.nbart_nir}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{data.0.bands.nbart_swir_1}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2200</b></td><td>{{data.0.bands.nbart_swir_2}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{data.0.band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, SWIR</b></td><td>{{data.0.band_derived.ndwi}}</td></tr><tr><td><b>MNDWI - Green, SWIR</b></td><td>{{data.0.band_derived.mndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n480,{{data.0.bands.nbart_blue}}\n560,{{data.0.bands.nbart_green}}\n660,{{data.0.bands.nbart_red}}\n870,{{data.0.bands.nbart_nir}}\n1610,{{data.0.bands.nbart_swir_1}}\n2200,{{data.0.bands.nbart_swir_2}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>",
+                                        "formats": {
+                                            "lat": {
+                                                "maximumFractionDigits": 5
+                                            },
+                                            "lon": {
+                                                "maximumFractionDigits": 5
+                                            }
+                                        }
+                                    },
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "584D3e"
+                                },
+                                {
+                                    "type": "wms",
                                     "name": "DEA Surface Reflectance (Landsat 8 OLI-TIRS)",
                                     "url": "https://ows.dea.ga.gov.au/",
                                     "opacity": 1,


### PR DESCRIPTION
Releasing Landsat 9 web service into production and addition to DEA Maps. 

DO NOT MERGE until the below tasks are complete:

- [ ] CMI Record is approved by Maree and we have go ahead for release
- [x] Web service description in this PR is updated with latest CMI link

Once this PR is merged - the following file will need to be updated with the Landsat 9 product id to include in OWS and Explorer updates
https://bitbucket.org/geoscienceaustralia/dea-airflow/src/master/dags/webapp_update/update_list.py