### PR TITLE
Fix paths in ABARES STAC

### DIFF
--- a/products/others/abares_clum_2020/abares_clum_2020.stac-item.json
+++ b/products/others/abares_clum_2020/abares_clum_2020.stac-item.json
@@ -374,7 +374,7 @@
       "type": "image/jpeg"
     },
     "alum_class": {
-      "href": "https://dea-public-data.s3-ap-southeast-2.amazonaws.com/projects/abares_clum_2020/clum_50m1220m.tiff",
+      "href": "clum_50m1220m.tiff",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "alum_class",
       "raster:bands": [

--- a/products/others/abares_clum_2020/abares_clum_2020.stac-item.json
+++ b/products/others/abares_clum_2020/abares_clum_2020.stac-item.json
@@ -353,7 +353,7 @@
   "links": [
     {
       "rel": "self",
-      "href": "s3://dea-public-data-dev/abares_clum_2020/abares_clum_2020.stac-item.json",
+      "href": "s3://dea-public-data/projects/abares_clum_2020/abares_clum_2020.stac-item.json",
       "type": "application/json"
     },
     {
@@ -374,7 +374,7 @@
       "type": "image/jpeg"
     },
     "alum_class": {
-      "href": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/abares_clum_2020/clum_50m1220m.tiff",
+      "href": "https://dea-public-data.s3-ap-southeast-2.amazonaws.com/projects/abares_clum_2020/clum_50m1220m.tiff",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "alum_class",
       "raster:bands": [


### PR DESCRIPTION
We can't currently access ABARES data on dev or prod:
![image](https://github.com/GeoscienceAustralia/dea-config/assets/17680388/9186af9e-7463-4e96-a84e-425c1540af47)


I think this is because some of the STAC paths are wrong. I've attempted to fix these below.