### PR TITLE
Add DEA Intertidal adaptive uncertainty layer

### DIFF
--- a/dev/services/wms/inventory.json
+++ b/dev/services/wms/inventory.json
@@ -703,13 +703,14 @@
             "product": [
                 "ga_s2ls_intertidal_cyear_3"
             ],
-            "styles_count": 7,
+            "styles_count": 8,
             "styles_list": [
                 "intertidal_elevation",
                 "intertidal_elevation_micro",
                 "intertidal_elevation_macro",
                 "intertidal_elevation_adaptive",
                 "intertidal_elevation_uncertainty",
+                "intertidal_elevation_uncertainty_adaptive",
                 "intertidal_exposure",
                 "intertidal_extents"
             ]

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
@@ -213,7 +213,7 @@ style_intertidal_elevation_adaptive = {
     "include_in_feature_info": False,
     "needed_bands": ["elevation", "ta_lot", "ta_hot"],
     "mpl_ramp": "viridis",
-    "range": [0.05, 0.7],
+    "range": [0.1, 0.7],
     "legend": {
         "begin": "0.0",
         "end": "1.0",

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
@@ -227,6 +227,35 @@ style_intertidal_elevation_adaptive = {
     },
 }
 
+style_intertidal_elevation_uncertainty_adaptive = {
+    "name": "intertidal_elevation_uncertainty_adaptive",
+    "title": "Elevation uncertainty (experimental)",
+    "abstract": "Intertidal elevation uncertainty",
+    "index_function": {
+        "function": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.uncertainty_adaptive",
+        "mapped_bands": True,
+        "kwargs": {
+            "band": "elevation_uncertainty",
+            "lot": "ta_lot",
+            "hot": "ta_hot",
+        },
+    },
+    "include_in_feature_info": False,
+    "needed_bands": ["elevation_uncertainty", "ta_lot", "ta_hot"],
+    "mpl_ramp": "inferno",
+    "range": [0.05, 0.3],
+    "legend": {
+        "begin": "0.05",
+        "end": "0.3",
+        "ticks": ["0.05", "0.3"],
+        "units": "",
+        "tick_labels": {
+            "0.05": {"label": "Low"},
+            "0.3": {"label": "High"},
+        },
+    },
+}
+
 # Create combined list that is imported and passed to the layer
 styles_intertidal_list = [
     style_intertidal_elevation,
@@ -234,6 +263,7 @@ styles_intertidal_list = [
     style_intertidal_elevation_macro,
     style_intertidal_elevation_adaptive,
     style_intertidal_elevation_uncertainty,
+    style_intertidal_elevation_uncertainty_adaptive,
     style_intertidal_exposure,
     style_intertidal_extents,
 ]

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
@@ -16,7 +16,7 @@ legend_intertidal_percentage_by_20 = {
 
 style_intertidal_elevation = {
     "name": "intertidal_elevation",
-    "title": "Elevation",
+    "title": "Elevation (mesotidal)",
     "abstract": "Intertidal elevation in metres above Mean Sea Level",
     "index_function": {
         "function": "datacube_ows.band_utils.single_band",
@@ -43,7 +43,7 @@ style_intertidal_elevation = {
 
 style_intertidal_elevation_micro = {
     "name": "intertidal_elevation_micro",
-    "title": "Elevation (microtidal style)",
+    "title": "Elevation (microtidal)",
     "abstract": "Intertidal elevation in metres above Mean Sea Level",
     "index_function": {
         "function": "datacube_ows.band_utils.single_band",
@@ -70,7 +70,7 @@ style_intertidal_elevation_micro = {
 
 style_intertidal_elevation_macro = {
     "name": "intertidal_elevation_macro",
-    "title": "Elevation (macrotidal style)",
+    "title": "Elevation (macrotidal)",
     "abstract": "Intertidal elevation in metres above Mean Sea Level",
     "index_function": {
         "function": "datacube_ows.band_utils.single_band",
@@ -199,7 +199,7 @@ style_intertidal_extents = {
 
 style_intertidal_elevation_adaptive = {
     "name": "intertidal_elevation_adaptive",
-    "title": "Elevation (experimental adaptive style)",
+    "title": "Elevation (adaptive)",
     "abstract": "Intertidal elevation in metres above Mean Sea Level",
     "index_function": {
         "function": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.elevation_adaptive",
@@ -228,7 +228,7 @@ style_intertidal_elevation_adaptive = {
 
 style_intertidal_elevation_uncertainty_adaptive = {
     "name": "intertidal_elevation_uncertainty_adaptive",
-    "title": "Elevation uncertainty (experimental)",
+    "title": "Elevation uncertainty (adaptive)",
     "abstract": "Intertidal elevation uncertainty",
     "index_function": {
         "function": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.uncertainty_adaptive",

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
@@ -215,14 +215,13 @@ style_intertidal_elevation_adaptive = {
     "mpl_ramp": "viridis",
     "range": [0.1, 0.7],
     "legend": {
-        "begin": "0.0",
-        "end": "1.0",
-        "ticks": ["0.0", "0.5", "1.0"],
+        "begin": "0.1",
+        "end": "0.7",
+        "ticks": ["0.1", "0.7"],
         "units": "",
         "tick_labels": {
-            "0.0": {"label": "Low"},
-            "0.5": {"label": ""},
-            "1.0": {"label": "High"},
+            "0.1": {"label": "Low"},
+            "0.7": {"label": "High"},
         },
     },
 }
@@ -243,14 +242,14 @@ style_intertidal_elevation_uncertainty_adaptive = {
     "include_in_feature_info": False,
     "needed_bands": ["elevation_uncertainty", "ta_lot", "ta_hot"],
     "mpl_ramp": "inferno",
-    "range": [0.05, 0.3],
+    "range": [0.1, 0.3],
     "legend": {
-        "begin": "0.05",
+        "begin": "0.1",
         "end": "0.3",
-        "ticks": ["0.05", "0.3"],
+        "ticks": ["0.1", "0.3"],
         "units": "",
         "tick_labels": {
-            "0.05": {"label": "Low"},
+            "0.1": {"label": "Low"},
             "0.3": {"label": "High"},
         },
     },

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
@@ -25,3 +25,19 @@ def elevation_adaptive(data, band, lot, hot, band_mapper=None):
     proportion_array = distance_to_min / otr
 
     return proportion_array
+
+
+@scalable
+def uncertainty_adaptive(data, band, lot, hot, band_mapper=None):
+    """
+    Experimental adaptive elevation uncertainty function, using
+    pixel-level tide metadata to calculate relative uncertainty.
+    """
+    
+    # Calculate observed tide range (max - min)
+    otr = data[hot] - data[lot]
+
+    # Calculate proportion
+    proportion_array = data[band] / otr
+
+    return proportion_array

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
@@ -33,7 +33,7 @@ def uncertainty_adaptive(data, band, lot, hot, band_mapper=None):
     Experimental adaptive elevation uncertainty function, using
     pixel-level tide metadata to calculate relative uncertainty.
     """
-    
+
     # Calculate observed tide range (max - min)
     otr = data[hot] - data[lot]
 


### PR DESCRIPTION
This adds a new adaptive uncertainty style to match the adaptive elevation style. It scales colours from uncertainty of 10% to 30% of the observed tide range.

Also makes some minor tweaks to the adaptive elevation style.