### PR TITLE
Remove extents from DEA Intertidal OWS style

### DIFF
--- a/dev/services/wms/inventory.json
+++ b/dev/services/wms/inventory.json
@@ -703,12 +703,11 @@
             "product": [
                 "ga_s2ls_intertidal_cyear_3"
             ],
-            "styles_count": 10,
+            "styles_count": 9,
             "styles_list": [
                 "intertidal_elevation_adaptive",                
                 "intertidal_elevation_uncertainty_adaptive",
                 "intertidal_exposure",
-                "intertidal_extents",
                 "intertidal_elevation_micro",
                 "intertidal_elevation_meso",
                 "intertidal_elevation_macro",

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/ows_intertidal_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/ows_intertidal_cfg.py
@@ -6,7 +6,6 @@ bands_intertidal = {
     "elevation": [],
     "elevation_uncertainty": [],
     "exposure": [],
-    "extents": [],
     "ta_hat": [],
     "ta_hot": [],
     "ta_lat": [],

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
@@ -150,53 +150,6 @@ style_intertidal_exposure = {
     "legend": legend_intertidal_percentage_by_20,
 }
 
-style_intertidal_extents = {
-    "name": "intertidal_extents",
-    "title": "Extents",
-    "abstract": "Intertidal Extents classification",
-    "needed_bands": ["extents"],
-    "value_map": {
-        "extents": [
-            {
-                "title": "Dry",
-                "abstract": "",
-                "values": [0],
-                "color": "#dddddd",
-            },
-            {
-                "title": "Inland intermittent wet",
-                "abstract": "",
-                "values": [1],
-                "color": "#00a7c8",
-            },
-            {
-                "title": "Inland persistent wet",
-                "abstract": "",
-                "values": [2],
-                "color": "#00667a",
-            },
-            {
-                "title": "Tidally influenced wet",
-                "abstract": "",
-                "values": [3],
-                "color": "#2a5fa1",
-            },
-            {
-                "title": "Intertidal (low confidence)",
-                "abstract": "",
-                "values": [4],
-                "color": "#ffe8a1",
-            },
-            {
-                "title": "Intertidal (high confidence)",
-                "abstract": "",
-                "values": [5],
-                "color": "#ffc001",
-            },
-        ]
-    }
-}
-
 style_intertidal_elevation_adaptive = {
     "name": "intertidal_elevation_adaptive",
     "title": "Elevation (adaptive)",
@@ -301,7 +254,6 @@ styles_intertidal_list = [
     style_intertidal_elevation_adaptive,
     style_intertidal_elevation_uncertainty_adaptive,
     style_intertidal_exposure,
-    style_intertidal_extents,
     style_intertidal_elevation_micro,
     style_intertidal_elevation_meso,
     style_intertidal_elevation_macro,


### PR DESCRIPTION
Temporarily remove Extents style from DEA Intertidal OWS layer (data has been removed from the first release of the product)