### PR TITLE
Prod OWS DEA Intertidal layer

### DIFF
--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -3121,9 +3121,138 @@
                             ]
                         },
                         {
+                            "id": "Fhh87i",
+                            "type": "group",
+                            "name": "DEA Intertidal",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Intertidal (Sentinel-2, Landsat)",
+                                    "url": "https://ows.dea.ga.gov.au/wms",
+                                    "opacity": 1,
+                                    "layers": "ga_s2ls_intertidal_cyear_3",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ga_s2ls_intertidal_cyear_3",
+                                    "dateFormat": "'Year: 'yyyy",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "shortReport": "<small>For more information and to download data, visit the <a href='https://knowledge.dea.ga.gov.au/data/product/dea-intertidal/'>DEA Intertidal product description</a></small>",
+                                    "featureInfoTemplate": {
+                                        "template": "<div style='width:510px'><h1 style='font-weight:normal'>Digital Earth Australia Intertidal</h1>This location had an elevation above modelled Mean Sea Level (MSL): <h1 style='font-weight:normal'><b>{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.elevation}}{{/terria.formatNumber}} metres (± {{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.elevation_uncertainty}}{{/terria.formatNumber}})</b></h1>It was exposed from tidal inundation for: <h2 style='font-weight:normal'><b>{{data.0.bands.exposure}}%</b> of the <b>{{#terria.formatDateTime}}{format: \"yyyy\"}{{data.0.time}}{{/terria.formatDateTime}}</b> analysis period</h2><hr><br>At this location, satellite data included images of the coast at tide heights from <b>{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.ta_lot}}{{/terria.formatNumber}}</b> to <b>+{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.ta_hot}}{{/terria.formatNumber}}</b> metres above MSL, compared to the full astronomical tide range of <b>{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.ta_lat}}{{/terria.formatNumber}}</b> to <b>+{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.ta_hat}}{{/terria.formatNumber}}</b> metres above MSL.<br><br>This resulted in satellite data observing <b>{{data.0.bands.ta_spread}}%</b> of the astronomical tide range, and failing to observe the lowest <b>{{data.0.bands.ta_offset_low}}%</b> and highest <b>{{data.0.bands.ta_offset_high}}%</b> of tides.<br><br><hr><br><small>For more information about intertidal mapping accuracy and limitations or to download data, visit the <a href='https://docs.dea.ga.gov.au/data/product/dea-intertidal-elevation-landsat/'>DEA Intertidal product description.</a></small><br/><br/></div>"
+                                    },
+                                    "id": "xfG556",       
+                                },
+                                {
+                                    "type": "geojson",
+                                    "name": "DEA Intertidal 32 km tile grid",
+                                    "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_s2ls_intertidal_cyear_3/ga_summary_grid_c3_32km_coastal.geojson",
+                                    "id": "67ttyU"
+                                },
+                            ]
+                        },
+                        {
+                            "id": "yC2aqy",
+                            "type": "group",
+                            "name": "DEA High and Low Tide Imagery (HLTC)",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Low Tide Imagery (Landsat)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "low_tide_composite",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "low_tide_composite",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "4XvQxE"
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA High Tide Imagery (Landsat)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "high_tide_composite",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "high_tide_composite",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "YLrxLi"
+                                },
+                                {
+                                    "type": "geojson",
+                                    "name": "DEA Low Tide polygons for data access",
+                                    "info": [
+                                        {
+                                            "name": "Abstract",
+                                            "content": "High Tide and Low Tide Composites 2.0.0 <p/> The High and Low Tide Composites product is composed of two surface reflectance composite mosaics of Landsat TM and ETM+ (Landsat 5 and Landsat 7 respectively) and OLI (Landsat 8) surface reflectance data (Li et al., 2012). These products have been produced using Digital Earth Australia (DEA). The two mosaics allow cloud free and noise reduced visualisation of the shallow water and inter-tidal coastal regions of Australia, as observed at high and low tide respectively (Sagar et al. 2018). <p/> The composites are generated utilising the geomedian approach of Roberts et al (2017) to ensure a valid surface reflectance spectra suitable for uses such as habitat mapping. The time range used for composite generation in each polygon of the mosaic is tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The concepts of the Observed Tidal Range (OTR), and Highest and Lowest Observed Tide (HOT, LOT) are discussed and described fully in Sagar et al. (2017) and the product description for the ITEM v 1.0 product (Geoscience Australia, 2016)."
+                                        },
+                                        {
+                                            "name": "Overview",
+                                            "content": "Inter-tidal zones are difficult regions to characterise due to the dynamic nature of the tide. They are highly changeable environments, subject to forcings from the land, sea and atmosphere and yet they form critical habitats for a wide range of organisms from birds to fish and sea grass. By harnessing the long archive of satellite imagery over Australia's coastal zones in the DEA and pairing the images with regional tidal modelling, the archive can be sorted by tide height rather than date, enabling the inter-tidal zone to be viewed at any stage of the tide regime. <p/> The High Low Tide Composites (HLTC_25) product is composed of two mosaics, distinguished by tide height, representing a composite image of the synthetic geomedian surface reflectance from Landsats 5 TM, Landsat 7 ETM+ and Landsat 8 OLI NBAR data (Li et al., 2012; Roberts et al., 2017). Oregon State Tidal Prediction (OTPS) software (Egbert and Erofeeva, 2002, 2010) was used to generate tide heights, relative to mean sea level, for the Australian continental coastline, split into 306 distinct tidal regions. These time and date stamped tidal values were then attributed to all coastal tile observations for their time of acquisition, creating a range of observed tide heights for the Australian coastline. The two mosaics in HLTC_25 are composited from the highest and lowest 20 % of observed tide in the ensemble and are termed HOT and LOT respectively. A geomedian composite for each Landsat band is calculated from the tiles in each ensemble subset to produce the respective HOT and LOT composites. Note that Landsat 7 ETM+ observations are excluded after May 2003 due to a large number of data artefacts. <p/> The time range used for composite generation in each of the 306 polygons of the mosaics are tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The maximum epoch for which the products are calculated is between 1995-2017, although this varies due to data resolution and observation quality. The product also includes a count of clear observations per pixel for both mosaics and attribute summaries per polygon that include the date range, the highest and lowest modeled astronomical tide as well as the highest and lowest observed tide for that time range, the total observation count and the maximum count of observations for any one pixel in the polygon, the polygon ID number (from 1 to 306), the polygon centroid in longitude and latitude and the count of tide stages attributed to every observation used in that polygon of the mosaic. For the count of tidal stage observations, e = ebbing tide, f = flowing tide, ph = peak high tide and pl = peak low tide. The tide stages were calculated by comparison to the modeled tide data for 15 minutes either side of the observation to determine the ebb, flow or peak movement of the tide. <p/> Observations are filtered to remove poor quality observations including cloud, cloud shadow and band saturation (of any band)."
+                                        },
+                                        {
+                                            "name": "Accuracy and limitations",
+                                            "content": "The accuracy of the tide height data is limited by the accuracy of the OTPS model. Tidal modelling on self-similar coastal polygons was performed to minimise regional uncertainty. <p/> Accuracies and limitations related to geomedian compositing of observations are discussed in Roberts et al (2017). <p/> Users should beware of seasonal and diurnal effects in the imagery, especially in the north east of Australia where the footprint of the highest and lowest astronomical tides are large. Consequently, where image acquisition misses the highest astronomical tide, for example, pooling effects of water are still visible in the landscape in lowest observed tidal composite imagery. <p/> This product has been rendered in both true colour and false colour. Validation and interpretation of surface features has not been attempted here. Interpretation of surface features is at the users own discretion."
+                                        },
+                                        {
+                                            "name": "File naming",
+                                            "content": "`<COUNT OR COMPOSITE>_<HIGH OR LOW>_<TIDAL POLYGON NUMBER>_<LONGITUDE>_<LATITUDE>_<START DATE>_<END DATE>_<PERCENTILE TIDE RANGE>` <p/> COUNT OR COMPOSITE refers to whether pixels contain composite observation values or the count of observations at that pixel location <br/>HIGH OR LOW refers to whether the content relates to High Tide values or Low Tide values <br/>TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <br/>LONGITUDE is the longitude of the centroid of the tidal polygon <br/>LATITUDE is the latitude of the centroid of the tidal polygon <br/>START DATE is the beginning of the date range covered by the file <br/>END DATE is the end of the date range covered by the file <br/>PERCENTILE TIDE RANGE indicates the percentile value used when calculating the composites <p/> The index of downloadable GeoTIFFs can be found here: <p/> http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/catalog.xml"
+                                        },
+                                        {
+                                            "name": "References",
+                                            "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmospheric Ocean. Technol. 19, 183-204. doi:10.1175/1520-0426(2002)019<0183:EIMOBO>2.0.CO;2 <p/> Egbert, G.D., Erofeeva, S.Y., 2010. The OSU TOPEX/Poseiden Global Inverse Solution TPXO [WWW Document]. TPXO8-Atlas Version 10. URL http://volkov.oce.orst.edu/tides/global.html (accessed 2.15.16). <p/> Geoscience Australia, 2016. Intertidal Extents Model (25m) v 1.0 Product Description. doi:10.4225/25/575F683E2A3AF <p/> Li, F., Jupp, D.L.B., Thankappan, M., Lymburner, L., Mueller, N., Lewis, A., Held, A., 2012. A physics-based atmospheric and BRDF correction for Landsat data over mountainous terrain. Remote Sens. Environ. 124, 756-770. doi:10.1016/j.rse.2012.06.018 <p/> Roberts, D., Mueller, N., McIntyre, A., 2017. High-dimensional pixel composites from Earth observation time series. IEEE Trans. Geosci. Remote Sens. In Press. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sens. Environ. 195, 153-169. doi:10.1016/j.rse.2017.04.009 <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
+                                        }
+                                    ],
+                                    "url": "https://data.dea.ga.gov.au/LHTC_Tides/low_composite_20.geojson",
+                                    "featureInfoTemplate": {
+                                        "template": "The tidal range at this location is {{modelLow}} to {{modelHigh}} meters relative to mean sea level (MSL). <p/> The low tide composite at this location was generated from imagery acquired in the lowest 20% of the observed tidal range which is between {{LIT}} and {{HIT}} meters relative to MSL, during the period of time of {{date_range}}. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/LHTC_Tides/COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.jpg'/> <figcaption>Observations used to generate the composite (black dots), in relation to the full modelled tidal range (blue) and complete archive (white dots) at this location</figcaption> </figure> <p/> Download the GeoTIFF for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif'>COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif</a>"
+                                    },
+                                    "id": "5SAK7J"
+                                },
+                                {
+                                    "type": "geojson",
+                                    "name": "DEA High Tide polygons for data access",
+                                    "info": [
+                                        {
+                                            "name": "Abstract",
+                                            "content": "High Tide and Low Tide Composites 2.0.0 <p/> The High and Low Tide Composites product is composed of two surface reflectance composite mosaics of Landsat TM and ETM+ (Landsat 5 and Landsat 7 respectively) and OLI (Landsat 8) surface reflectance data (Li et al., 2012). These products have been produced using Digital Earth Australia (DEA). The two mosaics allow cloud free and noise reduced visualisation of the shallow water and inter-tidal coastal regions of Australia, as observed at high and low tide respectively (Sagar et al. 2018). <p/> The composites are generated utilising the geomedian approach of Roberts et al (2017) to ensure a valid surface reflectance spectra suitable for uses such as habitat mapping. The time range used for composite generation in each polygon of the mosaic is tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The concepts of the Observed Tidal Range (OTR), and Highest and Lowest Observed Tide (HOT, LOT) are discussed and described fully in Sagar et al. (2017) and the product description for the ITEM v 1.0 product (Geoscience Australia, 2016)."
+                                        },
+                                        {
+                                            "name": "Overview",
+                                            "content": "Inter-tidal zones are difficult regions to characterise due to the dynamic nature of the tide. They are highly changeable environments, subject to forcings from the land, sea and atmosphere and yet they form critical habitats for a wide range of organisms from birds to fish and sea grass. By harnessing the long archive of satellite imagery over Australia's coastal zones in the DEA and pairing the images with regional tidal modelling, the archive can be sorted by tide height rather than date, enabling the inter-tidal zone to be viewed at any stage of the tide regime. <p/> The High Low Tide Composites (HLTC_25) product is composed of two mosaics, distinguished by tide height, representing a composite image of the synthetic geomedian surface reflectance from Landsats 5 TM, Landsat 7 ETM+ and Landsat 8 OLI NBAR data (Li et al., 2012; Roberts et al., 2017). Oregon State Tidal Prediction (OTPS) software (Egbert and Erofeeva, 2002, 2010) was used to generate tide heights, relative to mean sea level, for the Australian continental coastline, split into 306 distinct tidal regions. These time and date stamped tidal values were then attributed to all coastal tile observations for their time of acquisition, creating a range of observed tide heights for the Australian coastline. The two mosaics in HLTC_25 are composited from the highest and lowest 20 % of observed tide in the ensemble and are termed HOT and LOT respectively. A geomedian composite for each Landsat band is calculated from the tiles in each ensemble subset to produce the respective HOT and LOT composites. Note that Landsat 7 ETM+ observations are excluded after May 2003 due to a large number of data artefacts. <p/> The time range used for composite generation in each of the 306 polygons of the mosaics are tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The maximum epoch for which the products are calculated is between 1995-2017, although this varies due to data resolution and observation quality. The product also includes a count of clear observations per pixel for both mosaics and attribute summaries per polygon that include the date range, the highest and lowest modeled astronomical tide as well as the highest and lowest observed tide for that time range, the total observation count and the maximum count of observations for any one pixel in the polygon, the polygon ID number (from 1 to 306), the polygon centroid in longitude and latitude and the count of tide stages attributed to every observation used in that polygon of the mosaic. For the count of tidal stage observations, e = ebbing tide, f = flowing tide, ph = peak high tide and pl = peak low tide. The tide stages were calculated by comparison to the modeled tide data for 15 minutes either side of the observation to determine the ebb, flow or peak movement of the tide. <p/> Observations are filtered to remove poor quality observations including cloud, cloud shadow and band saturation (of any band)."
+                                        },
+                                        {
+                                            "name": "Accuracy and limitations",
+                                            "content": "The accuracy of the tide height data is limited by the accuracy of the OTPS model. Tidal modelling on self-similar coastal polygons was performed to minimise regional uncertainty. <p/> Accuracies and limitations related to geomedian compositing of observations are discussed in Roberts et al (2017). <p/> Users should beware of seasonal and diurnal effects in the imagery, especially in the north east of Australia where the footprint of the highest and lowest astronomical tides are large. Consequently, where image acquisition misses the highest astronomical tide, for example, pooling effects of water are still visible in the landscape in lowest observed tidal composite imagery. <p/> This product has been rendered in both true colour and false colour. Validation and interpretation of surface features has not been attempted here. Interpretation of surface features is at the users own discretion."
+                                        },
+                                        {
+                                            "name": "File naming",
+                                            "content": "`<COUNT OR COMPOSITE>_<HIGH OR LOW>_<TIDAL POLYGON NUMBER>_<LONGITUDE>_<LATITUDE>_<START DATE>_<END DATE>_<PERCENTILE TIDE RANGE>` <p/> COUNT OR COMPOSITE refers to whether pixels contain composite observation values or the count of observations at that pixel location <br/>HIGH OR LOW refers to whether the content relates to High Tide values or Low Tide values <br/>TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <br/>LONGITUDE is the longitude of the centroid of the tidal polygon <br/>LATITUDE is the latitude of the centroid of the tidal polygon <br/>START DATE is the beginning of the date range covered by the file <br/>END DATE is the end of the date range covered by the file <br/>PERCENTILE TIDE RANGE indicates the percentile value used when calculating the composites <p/> The index of downloadable GeoTIFFs can be found here: <p/> http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/catalog.xml"
+                                        },
+                                        {
+                                            "name": "References",
+                                            "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmospheric Ocean. Technol. 19, 183-204. doi:10.1175/1520-0426(2002)019<0183:EIMOBO>2.0.CO;2 <p/> Egbert, G.D., Erofeeva, S.Y., 2010. The OSU TOPEX/Poseiden Global Inverse Solution TPXO [WWW Document]. TPXO8-Atlas Version 10. URL http://volkov.oce.orst.edu/tides/global.html (accessed 2.15.16). <p/> Geoscience Australia, 2016. Intertidal Extents Model (25m) v 1.0 Product Description. doi:10.4225/25/575F683E2A3AF <p/> Li, F., Jupp, D.L.B., Thankappan, M., Lymburner, L., Mueller, N., Lewis, A., Held, A., 2012. A physics-based atmospheric and BRDF correction for Landsat data over mountainous terrain. Remote Sens. Environ. 124, 756-770. doi:10.1016/j.rse.2012.06.018 <p/> Roberts, D., Mueller, N., McIntyre, A., 2017. High-dimensional pixel composites from Earth observation time series. IEEE Trans. Geosci. Remote Sens. In Press. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sens. Environ. 195, 153-169. doi:10.1016/j.rse.2017.04.009 <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
+                                        }
+                                    ],
+                                    "url": "https://data.dea.ga.gov.au/LHTC_Tides/high_composite_20.geojson",
+                                    "featureInfoTemplate": {
+                                        "template": "The tidal range at this location is {{modelLow}} to {{modelHigh}} meters relative to mean sea level (MSL). <p/> The high tide composite at this location was generated from imagery acquired in the top 20% of the observed tidal range which is between {{LIT}} and {{HIT}} meters relative to MSL, during the period of time of {{date_range}}. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/LHTC_Tides/COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.jpg'/> <figcaption>Observations used to generate the composite (black dots), in relation to the full modelled tidal range (blue) and complete archive (white dots) at this location</figcaption> </figure> <p/> Download the GeoTIFF for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif'>COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif</a>"
+                                    },
+                                    "id": "IjP3T7"
+                                }
+                            ]
+                        },
+                        {
                             "id": "bsRRuv",
                             "type": "group",
-                            "name": "DEA Intertidal (ITEM, NIDEM)",
+                            "name": "Other",
                             "members": [
                                 {
                                     "type": "wms",
@@ -3141,10 +3270,7 @@
                                     "featureInfoTemplate": {
                                         "template": "<div style='width:480px'><h2 style='font-weight:normal'>Digital Earth Australia Intertidal Elevation</h2>Elevation relative to Mean Sea Level (approximately equivelent to AHD): <h1 style='font-weight:normal'><b>{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.nidem}}{{/terria.formatNumber}} metres</b></h1><i>For more information about intertidal mapping accuracy and limitations or to download data, visit the <a href='https://knowledge.dea.ga.gov.au/data/product/dea-intertidal-elevation-landsat/'>DEA Intertidal Elevation product description.</a></i><br/><br/></div>"
                                     },
-                                    "id": "bWICtK",
-                                    "shareKeys": [
-                                        "Root Group/Coastal/National Intertidal Digital Elevation Model"
-                                    ]
+                                    "id": "bWICtK"
                                 },
                                 {
                                     "type": "wms",
@@ -3158,10 +3284,7 @@
                                     "tileErrorHandlingOptions": {
                                         "ignoreUnknownTileErrors": true
                                     },
-                                    "id": "cXSDLg",
-                                    "shareKeys": [
-                                        "Root Group/Coastal/Intertidal extent model/Intertidal Extent"
-                                    ]
+                                    "id": "cXSDLg"
                                 },
                                 {
                                     "type": "wms",
@@ -3175,10 +3298,7 @@
                                     "tileErrorHandlingOptions": {
                                         "ignoreUnknownTileErrors": true
                                     },
-                                    "id": "6E5V7V",
-                                    "shareKeys": [
-                                        "Root Group/Coastal/Intertidal extent model/Intertidal Extent Confidence"
-                                    ]
+                                    "id": "6E5V7V"
                                 },
                                 {
                                     "type": "geojson",
@@ -3219,124 +3339,9 @@
                                             }
                                         }
                                     },
-                                    "id": "6fBRXw",
-                                    "shareKeys": [
-                                        "Root Group/Coastal/Intertidal extent model/Intertidal Extent Polygons data access"
-                                    ]
+                                    "id": "6fBRXw"
                                 }
-                            ],
-                            "shareKeys": ["Root Group/Coastal/Intertidal extent model"]
-                        },
-                        {
-                            "id": "yC2aqy",
-                            "type": "group",
-                            "name": "DEA High and Low Tide Imagery (HLTC)",
-                            "members": [
-                                {
-                                    "type": "wms",
-                                    "name": "DEA Low Tide Imagery (Landsat)",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "low_tide_composite",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "low_tide_composite",
-                                    "leafletUpdateInterval": 750,
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "4XvQxE",
-                                    "shareKeys": [
-                                        "Root Group/Coastal/Low tide satellite images/Low tide Landsat satellite images"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "DEA High Tide Imagery (Landsat)",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "high_tide_composite",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "high_tide_composite",
-                                    "leafletUpdateInterval": 750,
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "YLrxLi",
-                                    "shareKeys": [
-                                        "Root Group/Coastal/High tide satellite images/High tide Landsat satellite images"
-                                    ]
-                                },
-                                {
-                                    "type": "geojson",
-                                    "name": "DEA Low Tide polygons for data access",
-                                    "info": [
-                                        {
-                                            "name": "Abstract",
-                                            "content": "High Tide and Low Tide Composites 2.0.0 <p/> The High and Low Tide Composites product is composed of two surface reflectance composite mosaics of Landsat TM and ETM+ (Landsat 5 and Landsat 7 respectively) and OLI (Landsat 8) surface reflectance data (Li et al., 2012). These products have been produced using Digital Earth Australia (DEA). The two mosaics allow cloud free and noise reduced visualisation of the shallow water and inter-tidal coastal regions of Australia, as observed at high and low tide respectively (Sagar et al. 2018). <p/> The composites are generated utilising the geomedian approach of Roberts et al (2017) to ensure a valid surface reflectance spectra suitable for uses such as habitat mapping. The time range used for composite generation in each polygon of the mosaic is tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The concepts of the Observed Tidal Range (OTR), and Highest and Lowest Observed Tide (HOT, LOT) are discussed and described fully in Sagar et al. (2017) and the product description for the ITEM v 1.0 product (Geoscience Australia, 2016)."
-                                        },
-                                        {
-                                            "name": "Overview",
-                                            "content": "Inter-tidal zones are difficult regions to characterise due to the dynamic nature of the tide. They are highly changeable environments, subject to forcings from the land, sea and atmosphere and yet they form critical habitats for a wide range of organisms from birds to fish and sea grass. By harnessing the long archive of satellite imagery over Australia's coastal zones in the DEA and pairing the images with regional tidal modelling, the archive can be sorted by tide height rather than date, enabling the inter-tidal zone to be viewed at any stage of the tide regime. <p/> The High Low Tide Composites (HLTC_25) product is composed of two mosaics, distinguished by tide height, representing a composite image of the synthetic geomedian surface reflectance from Landsats 5 TM, Landsat 7 ETM+ and Landsat 8 OLI NBAR data (Li et al., 2012; Roberts et al., 2017). Oregon State Tidal Prediction (OTPS) software (Egbert and Erofeeva, 2002, 2010) was used to generate tide heights, relative to mean sea level, for the Australian continental coastline, split into 306 distinct tidal regions. These time and date stamped tidal values were then attributed to all coastal tile observations for their time of acquisition, creating a range of observed tide heights for the Australian coastline. The two mosaics in HLTC_25 are composited from the highest and lowest 20 % of observed tide in the ensemble and are termed HOT and LOT respectively. A geomedian composite for each Landsat band is calculated from the tiles in each ensemble subset to produce the respective HOT and LOT composites. Note that Landsat 7 ETM+ observations are excluded after May 2003 due to a large number of data artefacts. <p/> The time range used for composite generation in each of the 306 polygons of the mosaics are tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The maximum epoch for which the products are calculated is between 1995-2017, although this varies due to data resolution and observation quality. The product also includes a count of clear observations per pixel for both mosaics and attribute summaries per polygon that include the date range, the highest and lowest modeled astronomical tide as well as the highest and lowest observed tide for that time range, the total observation count and the maximum count of observations for any one pixel in the polygon, the polygon ID number (from 1 to 306), the polygon centroid in longitude and latitude and the count of tide stages attributed to every observation used in that polygon of the mosaic. For the count of tidal stage observations, e = ebbing tide, f = flowing tide, ph = peak high tide and pl = peak low tide. The tide stages were calculated by comparison to the modeled tide data for 15 minutes either side of the observation to determine the ebb, flow or peak movement of the tide. <p/> Observations are filtered to remove poor quality observations including cloud, cloud shadow and band saturation (of any band)."
-                                        },
-                                        {
-                                            "name": "Accuracy and limitations",
-                                            "content": "The accuracy of the tide height data is limited by the accuracy of the OTPS model. Tidal modelling on self-similar coastal polygons was performed to minimise regional uncertainty. <p/> Accuracies and limitations related to geomedian compositing of observations are discussed in Roberts et al (2017). <p/> Users should beware of seasonal and diurnal effects in the imagery, especially in the north east of Australia where the footprint of the highest and lowest astronomical tides are large. Consequently, where image acquisition misses the highest astronomical tide, for example, pooling effects of water are still visible in the landscape in lowest observed tidal composite imagery. <p/> This product has been rendered in both true colour and false colour. Validation and interpretation of surface features has not been attempted here. Interpretation of surface features is at the users own discretion."
-                                        },
-                                        {
-                                            "name": "File naming",
-                                            "content": "`<COUNT OR COMPOSITE>_<HIGH OR LOW>_<TIDAL POLYGON NUMBER>_<LONGITUDE>_<LATITUDE>_<START DATE>_<END DATE>_<PERCENTILE TIDE RANGE>` <p/> COUNT OR COMPOSITE refers to whether pixels contain composite observation values or the count of observations at that pixel location <br/>HIGH OR LOW refers to whether the content relates to High Tide values or Low Tide values <br/>TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <br/>LONGITUDE is the longitude of the centroid of the tidal polygon <br/>LATITUDE is the latitude of the centroid of the tidal polygon <br/>START DATE is the beginning of the date range covered by the file <br/>END DATE is the end of the date range covered by the file <br/>PERCENTILE TIDE RANGE indicates the percentile value used when calculating the composites <p/> The index of downloadable GeoTIFFs can be found here: <p/> http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/catalog.xml"
-                                        },
-                                        {
-                                            "name": "References",
-                                            "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmospheric Ocean. Technol. 19, 183-204. doi:10.1175/1520-0426(2002)019<0183:EIMOBO>2.0.CO;2 <p/> Egbert, G.D., Erofeeva, S.Y., 2010. The OSU TOPEX/Poseiden Global Inverse Solution TPXO [WWW Document]. TPXO8-Atlas Version 10. URL http://volkov.oce.orst.edu/tides/global.html (accessed 2.15.16). <p/> Geoscience Australia, 2016. Intertidal Extents Model (25m) v 1.0 Product Description. doi:10.4225/25/575F683E2A3AF <p/> Li, F., Jupp, D.L.B., Thankappan, M., Lymburner, L., Mueller, N., Lewis, A., Held, A., 2012. A physics-based atmospheric and BRDF correction for Landsat data over mountainous terrain. Remote Sens. Environ. 124, 756-770. doi:10.1016/j.rse.2012.06.018 <p/> Roberts, D., Mueller, N., McIntyre, A., 2017. High-dimensional pixel composites from Earth observation time series. IEEE Trans. Geosci. Remote Sens. In Press. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sens. Environ. 195, 153-169. doi:10.1016/j.rse.2017.04.009 <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
-                                        }
-                                    ],
-                                    "url": "https://data.dea.ga.gov.au/LHTC_Tides/low_composite_20.geojson",
-                                    "featureInfoTemplate": {
-                                        "template": "The tidal range at this location is {{modelLow}} to {{modelHigh}} meters relative to mean sea level (MSL). <p/> The low tide composite at this location was generated from imagery acquired in the lowest 20% of the observed tidal range which is between {{LIT}} and {{HIT}} meters relative to MSL, during the period of time of {{date_range}}. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/LHTC_Tides/COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.jpg'/> <figcaption>Observations used to generate the composite (black dots), in relation to the full modelled tidal range (blue) and complete archive (white dots) at this location</figcaption> </figure> <p/> Download the GeoTIFF for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif'>COMPOSITE_LOW_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif</a>"
-                                    },
-                                    "id": "5SAK7J",
-                                    "shareKeys": [
-                                        "Root Group/Coastal/Low tide satellite images/Low Tide Polygons for data access"
-                                    ]
-                                },
-                                {
-                                    "type": "geojson",
-                                    "name": "DEA High Tide polygons for data access",
-                                    "info": [
-                                        {
-                                            "name": "Abstract",
-                                            "content": "High Tide and Low Tide Composites 2.0.0 <p/> The High and Low Tide Composites product is composed of two surface reflectance composite mosaics of Landsat TM and ETM+ (Landsat 5 and Landsat 7 respectively) and OLI (Landsat 8) surface reflectance data (Li et al., 2012). These products have been produced using Digital Earth Australia (DEA). The two mosaics allow cloud free and noise reduced visualisation of the shallow water and inter-tidal coastal regions of Australia, as observed at high and low tide respectively (Sagar et al. 2018). <p/> The composites are generated utilising the geomedian approach of Roberts et al (2017) to ensure a valid surface reflectance spectra suitable for uses such as habitat mapping. The time range used for composite generation in each polygon of the mosaic is tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The concepts of the Observed Tidal Range (OTR), and Highest and Lowest Observed Tide (HOT, LOT) are discussed and described fully in Sagar et al. (2017) and the product description for the ITEM v 1.0 product (Geoscience Australia, 2016)."
-                                        },
-                                        {
-                                            "name": "Overview",
-                                            "content": "Inter-tidal zones are difficult regions to characterise due to the dynamic nature of the tide. They are highly changeable environments, subject to forcings from the land, sea and atmosphere and yet they form critical habitats for a wide range of organisms from birds to fish and sea grass. By harnessing the long archive of satellite imagery over Australia's coastal zones in the DEA and pairing the images with regional tidal modelling, the archive can be sorted by tide height rather than date, enabling the inter-tidal zone to be viewed at any stage of the tide regime. <p/> The High Low Tide Composites (HLTC_25) product is composed of two mosaics, distinguished by tide height, representing a composite image of the synthetic geomedian surface reflectance from Landsats 5 TM, Landsat 7 ETM+ and Landsat 8 OLI NBAR data (Li et al., 2012; Roberts et al., 2017). Oregon State Tidal Prediction (OTPS) software (Egbert and Erofeeva, 2002, 2010) was used to generate tide heights, relative to mean sea level, for the Australian continental coastline, split into 306 distinct tidal regions. These time and date stamped tidal values were then attributed to all coastal tile observations for their time of acquisition, creating a range of observed tide heights for the Australian coastline. The two mosaics in HLTC_25 are composited from the highest and lowest 20 % of observed tide in the ensemble and are termed HOT and LOT respectively. A geomedian composite for each Landsat band is calculated from the tiles in each ensemble subset to produce the respective HOT and LOT composites. Note that Landsat 7 ETM+ observations are excluded after May 2003 due to a large number of data artefacts. <p/> The time range used for composite generation in each of the 306 polygons of the mosaics are tailored to ensure dynamic coastal features are captured whilst still allowing a clean and cloud free composite to be generated. The maximum epoch for which the products are calculated is between 1995-2017, although this varies due to data resolution and observation quality. The product also includes a count of clear observations per pixel for both mosaics and attribute summaries per polygon that include the date range, the highest and lowest modeled astronomical tide as well as the highest and lowest observed tide for that time range, the total observation count and the maximum count of observations for any one pixel in the polygon, the polygon ID number (from 1 to 306), the polygon centroid in longitude and latitude and the count of tide stages attributed to every observation used in that polygon of the mosaic. For the count of tidal stage observations, e = ebbing tide, f = flowing tide, ph = peak high tide and pl = peak low tide. The tide stages were calculated by comparison to the modeled tide data for 15 minutes either side of the observation to determine the ebb, flow or peak movement of the tide. <p/> Observations are filtered to remove poor quality observations including cloud, cloud shadow and band saturation (of any band)."
-                                        },
-                                        {
-                                            "name": "Accuracy and limitations",
-                                            "content": "The accuracy of the tide height data is limited by the accuracy of the OTPS model. Tidal modelling on self-similar coastal polygons was performed to minimise regional uncertainty. <p/> Accuracies and limitations related to geomedian compositing of observations are discussed in Roberts et al (2017). <p/> Users should beware of seasonal and diurnal effects in the imagery, especially in the north east of Australia where the footprint of the highest and lowest astronomical tides are large. Consequently, where image acquisition misses the highest astronomical tide, for example, pooling effects of water are still visible in the landscape in lowest observed tidal composite imagery. <p/> This product has been rendered in both true colour and false colour. Validation and interpretation of surface features has not been attempted here. Interpretation of surface features is at the users own discretion."
-                                        },
-                                        {
-                                            "name": "File naming",
-                                            "content": "`<COUNT OR COMPOSITE>_<HIGH OR LOW>_<TIDAL POLYGON NUMBER>_<LONGITUDE>_<LATITUDE>_<START DATE>_<END DATE>_<PERCENTILE TIDE RANGE>` <p/> COUNT OR COMPOSITE refers to whether pixels contain composite observation values or the count of observations at that pixel location <br/>HIGH OR LOW refers to whether the content relates to High Tide values or Low Tide values <br/>TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <br/>LONGITUDE is the longitude of the centroid of the tidal polygon <br/>LATITUDE is the latitude of the centroid of the tidal polygon <br/>START DATE is the beginning of the date range covered by the file <br/>END DATE is the end of the date range covered by the file <br/>PERCENTILE TIDE RANGE indicates the percentile value used when calculating the composites <p/> The index of downloadable GeoTIFFs can be found here: <p/> http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalog/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/catalog.xml"
-                                        },
-                                        {
-                                            "name": "References",
-                                            "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmospheric Ocean. Technol. 19, 183-204. doi:10.1175/1520-0426(2002)019<0183:EIMOBO>2.0.CO;2 <p/> Egbert, G.D., Erofeeva, S.Y., 2010. The OSU TOPEX/Poseiden Global Inverse Solution TPXO [WWW Document]. TPXO8-Atlas Version 10. URL http://volkov.oce.orst.edu/tides/global.html (accessed 2.15.16). <p/> Geoscience Australia, 2016. Intertidal Extents Model (25m) v 1.0 Product Description. doi:10.4225/25/575F683E2A3AF <p/> Li, F., Jupp, D.L.B., Thankappan, M., Lymburner, L., Mueller, N., Lewis, A., Held, A., 2012. A physics-based atmospheric and BRDF correction for Landsat data over mountainous terrain. Remote Sens. Environ. 124, 756-770. doi:10.1016/j.rse.2012.06.018 <p/> Roberts, D., Mueller, N., McIntyre, A., 2017. High-dimensional pixel composites from Earth observation time series. IEEE Trans. Geosci. Remote Sens. In Press. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sens. Environ. 195, 153-169. doi:10.1016/j.rse.2017.04.009 <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
-                                        }
-                                    ],
-                                    "url": "https://data.dea.ga.gov.au/LHTC_Tides/high_composite_20.geojson",
-                                    "featureInfoTemplate": {
-                                        "template": "The tidal range at this location is {{modelLow}} to {{modelHigh}} meters relative to mean sea level (MSL). <p/> The high tide composite at this location was generated from imagery acquired in the top 20% of the observed tidal range which is between {{LIT}} and {{HIT}} meters relative to MSL, during the period of time of {{date_range}}. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/LHTC_Tides/COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.jpg'/> <figcaption>Observations used to generate the composite (black dots), in relation to the full modelled tidal range (blue) and complete archive (white dots) at this location</figcaption> </figure> <p/> Download the GeoTIFF for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/HLTC/HLTC_2_0/geotiff/COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif'>COMPOSITE_HIGH_{{ID}}_{{lon}}_{{lat}}_{{start_date}}_{{end_date}}_PER_20.tif</a>"
-                                    },
-                                    "id": "IjP3T7",
-                                    "shareKeys": [
-                                        "Root Group/Coastal/High tide satellite images/High Tide Polygons for data access"
-                                    ]
-                                }
-                            ],
-                            "shareKeys": [
-                                "Root Group/Coastal/High tide satellite images"
+                            
                             ]
                         }
                     ],

--- a/prod/services/wms/inventory.json
+++ b/prod/services/wms/inventory.json
@@ -1,5 +1,5 @@
 {
-    "total_layers_count": 64,
+    "total_layers_count": 65,
     "layers": [
          {
             "layer": "s2_ls_combined",
@@ -577,6 +577,18 @@
                 "annual_wofs_frequency_blues_transparent_3",
                 "annual_wofs_wet_3",
                 "annual_wofs_clear_3"
+            ]
+        },
+        {
+            "layer": "ga_s2ls_intertidal_cyear_3",
+            "product": [
+                "ga_s2ls_intertidal_cyear_3"
+            ],
+            "styles_count": 3,
+            "styles_list": [
+                "intertidal_elevation_adaptive",                
+                "intertidal_elevation_uncertainty_adaptive",
+                "intertidal_exposure"
             ]
         },
         {

--- a/prod/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/ows_intertidal_cfg.py
+++ b/prod/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/ows_intertidal_cfg.py
@@ -1,0 +1,49 @@
+from ows_refactored.ows_reslim_cfg import reslim_standard
+from ows_refactored.sea_ocean_coast.intertidal_c3.style_intertidal_cfg import \
+    styles_intertidal_list
+
+bands_intertidal = {
+    "elevation": [],
+    "elevation_uncertainty": [],
+    "exposure": [],
+    "ta_hat": [],
+    "ta_hot": [],
+    "ta_lat": [],
+    "ta_lot": [],
+    "ta_offset_high": [],
+    "ta_offset_low": [],
+    "ta_spread": [],
+    "qa_ndwi_corr": [],
+    "qa_ndwi_freq": [],
+}
+
+abstract_intertidal = """Geoscience Australia Sentinel-2 Landsat Intertidal Calendar Year Collection 3
+
+The DEA Intertidal product suite maps the changing extent, elevation and topography of Australia's exposed intertidal zone, the complex zone that defines the interface between land and sea.
+
+Incorporating both Sentinel-2 and Landsat data, the product suite provides an annual 10 m resolution elevation product for the intertidal zone, enabling users to better monitor and understand some of the most dynamic regions of Australia’s coastlines. Utilising an improved tidal modelling capability, the product suite includes a continental scale mapping of intertidal exposure over time, enabling scientists and managers to integrate the data into ecological and migratory species applications and modelling.
+
+https://knowledge.dea.ga.gov.au/data/product/dea-intertidal/
+
+For service status information, see https://status.dea.ga.gov.au"""
+
+dea_intertidal_layer = {
+    "title": "DEA Intertidal (Sentinel-2, Landsat)",
+    "name": "ga_s2ls_intertidal_cyear_3",
+    "abstract": abstract_intertidal,
+    "product_name": "ga_s2ls_intertidal_cyear_3",
+    "bands": bands_intertidal,
+    "time_resolution": "summary",
+    "resource_limits": reslim_standard,
+    "native_crs": "EPSG:3577",
+    "native_resolution": [10, -10],
+    "image_processing": {
+        "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
+        "always_fetch_bands": [],
+        "manual_merge": False,
+    },
+    "styling": {
+        "default_style": "intertidal_elevation_adaptive",
+        "styles": styles_intertidal_list,
+    },
+}

--- a/prod/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
+++ b/prod/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
@@ -254,10 +254,4 @@ styles_intertidal_list = [
     style_intertidal_elevation_adaptive,
     style_intertidal_elevation_uncertainty_adaptive,
     style_intertidal_exposure,
-    style_intertidal_elevation_micro,
-    style_intertidal_elevation_meso,
-    style_intertidal_elevation_macro,
-    style_intertidal_elevation_uncertainty,
-    style_intertidal_corr,
-    style_intertidal_freq,
 ]

--- a/prod/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
+++ b/prod/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
@@ -1,0 +1,263 @@
+legend_intertidal_percentage_by_20 = {
+    "begin": "0.0",
+    "end": "100",
+    "decimal_places": 1,
+    "ticks_every": "20",
+    "units": "%",
+    "tick_labels": {
+        "0": {"label": "0"},
+        "20": {"label": "20"},
+        "40": {"label": "40"},
+        "60": {"label": "60"},
+        "80": {"label": "80"},
+        "100": {"label": "100"},
+    },
+}
+
+style_intertidal_elevation_meso = {
+    "name": "intertidal_elevation_meso",
+    "title": "Elevation (mesotidal)",
+    "abstract": "Intertidal elevation in metres above Mean Sea Level",
+    "index_function": {
+        "function": "datacube_ows.band_utils.single_band",
+        "mapped_bands": True,
+        "kwargs": {
+            "band": "elevation",
+        },
+    },
+    "include_in_feature_info": False,
+    "needed_bands": ["elevation"],
+    "mpl_ramp": "viridis",
+    "range": [-2.0, 1.0],
+    "legend": {
+        "begin": "-2.0",
+        "end": "1.0",
+        "ticks": ["-2.0", "-1.0", "0.0", "1.0"],
+        "units": "metres above Mean Sea Level",
+        "tick_labels": {
+            "1.0": {"prefix": ">"},
+            "-2.0": {"prefix": "<"},
+        },
+    },
+}
+
+style_intertidal_elevation_micro = {
+    "name": "intertidal_elevation_micro",
+    "title": "Elevation (microtidal)",
+    "abstract": "Intertidal elevation in metres above Mean Sea Level",
+    "index_function": {
+        "function": "datacube_ows.band_utils.single_band",
+        "mapped_bands": True,
+        "kwargs": {
+            "band": "elevation",
+        },
+    },
+    "include_in_feature_info": False,
+    "needed_bands": ["elevation"],
+    "mpl_ramp": "viridis",
+    "range": [-1.0, 0.5],
+    "legend": {
+        "begin": "-1.0",
+        "end": "0.5",
+        "ticks": ["-1.0", "-0.5", "0.0", "0.5"],
+        "units": "metres above Mean Sea Level",
+        "tick_labels": {
+            "0.5": {"prefix": ">"},
+            "-1.0": {"prefix": "<"},
+        },
+    },
+}
+
+style_intertidal_elevation_macro = {
+    "name": "intertidal_elevation_macro",
+    "title": "Elevation (macrotidal)",
+    "abstract": "Intertidal elevation in metres above Mean Sea Level",
+    "index_function": {
+        "function": "datacube_ows.band_utils.single_band",
+        "mapped_bands": True,
+        "kwargs": {
+            "band": "elevation",
+        },
+    },
+    "include_in_feature_info": False,
+    "needed_bands": ["elevation"],
+    "mpl_ramp": "viridis",
+    "range": [-4.0, 2.0],
+    "legend": {
+        "begin": "-4.0",
+        "end": "2.0",
+        "ticks": ["-4.0", "-2.0", "0.0", "2.0"],
+        "units": "metres above Mean Sea Level",
+        "tick_labels": {
+            "2.0": {"prefix": ">"},
+            "-4.0": {"prefix": "<"},
+        },
+    },
+}
+
+style_intertidal_elevation_uncertainty = {
+    "name": "intertidal_elevation_uncertainty",
+    "title": "Elevation uncertainty",
+    "abstract": "Intertidal elevation uncertainty in metres",
+    "index_function": {
+        "function": "datacube_ows.band_utils.single_band",
+        "mapped_bands": True,
+        "kwargs": {
+            "band": "elevation_uncertainty",
+        },
+    },
+    "include_in_feature_info": False,
+    "needed_bands": ["elevation_uncertainty"],
+    "mpl_ramp": "inferno",
+    "range": [0.0, 1.0],
+    "legend": {
+        "begin": "0.0",
+        "end": "1.0",
+        "ticks": ["0.0", "0.5", "1.0"],
+        "units": "metres",
+        "tick_labels": {
+            "1.0": {"prefix": ">"},
+        },
+    },
+}
+
+style_intertidal_exposure = {
+    "name": "intertidal_exposure",
+    "title": "Exposure",
+    "abstract": "Intertidal exposure in percent of time exposed to air",
+    "index_function": {
+        "function": "datacube_ows.band_utils.single_band",
+        "mapped_bands": True,
+        "kwargs": {
+            "band": "exposure",
+        },
+    },
+    "include_in_feature_info": False,
+    "needed_bands": ["exposure"],
+    "color_ramp": [
+        {"value": 0, "color": '#2f0f3d'},
+        {'value': 10, 'color': '#4f1552'},
+        {'value': 20, 'color': '#72195f'},
+        {'value': 30, 'color': '#931f63'},
+        {'value': 40, 'color': '#b32e5e'},
+        {'value': 50, 'color': '#ce4356'},
+        {'value': 60, 'color': '#e26152'},
+        {'value': 70, 'color': '#ee845d'},
+        {'value': 80, 'color': '#f5a672'},
+        {'value': 90, 'color': '#faca8f'},
+        {'value': 100, 'color': '#fdedb0'}
+    ],
+    "legend": legend_intertidal_percentage_by_20,
+}
+
+style_intertidal_elevation_adaptive = {
+    "name": "intertidal_elevation_adaptive",
+    "title": "Elevation",
+    "abstract": "Intertidal elevation in metres above Mean Sea Level",
+    "index_function": {
+        "function": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.elevation_adaptive",
+        "mapped_bands": True,
+        "kwargs": {
+            "band": "elevation",
+            "lot": "ta_lot",
+            "hot": "ta_hot",
+        },
+    },
+    "include_in_feature_info": False,
+    "needed_bands": ["elevation", "ta_lot", "ta_hot"],
+    "mpl_ramp": "viridis",
+    "range": [0.1, 0.7],
+    "legend": {
+        "begin": "0.1",
+        "end": "0.7",
+        "ticks": ["0.1", "0.7"],
+        "units": "",
+        "tick_labels": {
+            "0.1": {"label": "Low"},
+            "0.7": {"label": "High"},
+        },
+    },
+}
+
+style_intertidal_elevation_uncertainty_adaptive = {
+    "name": "intertidal_elevation_uncertainty_adaptive",
+    "title": "Elevation uncertainty",
+    "abstract": "Intertidal elevation uncertainty",
+    "index_function": {
+        "function": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.uncertainty_adaptive",
+        "mapped_bands": True,
+        "kwargs": {
+            "band": "elevation_uncertainty",
+            "lot": "ta_lot",
+            "hot": "ta_hot",
+        },
+    },
+    "include_in_feature_info": False,
+    "needed_bands": ["elevation_uncertainty", "ta_lot", "ta_hot"],
+    "mpl_ramp": "inferno",
+    "range": [0.0, 0.3],
+    "legend": {
+        "begin": "0.0",
+        "end": "0.3",
+        "ticks": ["0.0", "0.3"],
+        "units": "",
+        "tick_labels": {
+            "0.0": {"label": "Low"},
+            "0.3": {"label": "High"},
+        },
+    },
+}
+
+style_intertidal_corr = {
+    "name": "intertidal_corr",
+    "title": "NDWI tide correlation",
+    "abstract": "Correlation between NDWI and tide height",
+    "index_function": {
+        "function": "datacube_ows.band_utils.single_band",
+        "mapped_bands": True,
+        "kwargs": {
+            "band": "qa_ndwi_corr",
+        },
+    },
+    "include_in_feature_info": False,
+    "needed_bands": ["qa_ndwi_corr"],
+    "mpl_ramp": "RdBu",
+    "range": [-0.5, 0.5],
+    "legend": {
+        "begin": "-0.5",
+        "end": "0.5",
+        "ticks": ["-0.5", "0.0", "0.5"],
+        "units": "correlation",
+    },
+}
+
+style_intertidal_freq = {
+    "name": "intertidal_freq",
+    "title": "NDWI frequency",
+    "abstract": "NDWI inundation frequency",
+    "index_function": {
+        "function": "datacube_ows.band_utils.single_band",
+        "mapped_bands": True,
+        "kwargs": {
+            "band": "qa_ndwi_freq",
+        },
+    },
+    "include_in_feature_info": False,
+    "needed_bands": ["qa_ndwi_freq"],
+    "mpl_ramp": "RdBu",
+    "range": [0, 100],
+    "legend": legend_intertidal_percentage_by_20,
+}
+
+# Create combined list that is imported and passed to the layer
+styles_intertidal_list = [
+    style_intertidal_elevation_adaptive,
+    style_intertidal_elevation_uncertainty_adaptive,
+    style_intertidal_exposure,
+    style_intertidal_elevation_micro,
+    style_intertidal_elevation_meso,
+    style_intertidal_elevation_macro,
+    style_intertidal_elevation_uncertainty,
+    style_intertidal_corr,
+    style_intertidal_freq,
+]

--- a/prod/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
+++ b/prod/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
@@ -1,0 +1,43 @@
+from datacube_ows.band_utils import scalable
+
+
+@scalable
+def elevation_adaptive(data, band, lot, hot, band_mapper=None):
+    """
+    Experimental adaptive elevation function, using pixel-level
+    tide metadata to calculate relative elevation for any
+    given location.
+
+    This implementation should be free of any tile-based
+    discontinuities in the resulting visualisation.
+
+    # TODO: Add hillshading
+    """
+
+    # Calculate observed tide range (max - min)
+    otr = data[hot] - data[lot]
+
+    # Calculate distance between elevation and minumum
+    # observed tide height
+    distance_to_min = data[band] - data[lot]
+
+    # Calculate proportion along observed tide range
+    proportion_array = distance_to_min / otr
+
+    return proportion_array
+
+
+@scalable
+def uncertainty_adaptive(data, band, lot, hot, band_mapper=None):
+    """
+    Experimental adaptive elevation uncertainty function, using
+    pixel-level tide metadata to calculate relative uncertainty.
+    """
+
+    # Calculate observed tide range (max - min)
+    otr = data[hot] - data[lot]
+
+    # Calculate proportion
+    proportion_array = data[band] / otr
+
+    return proportion_array

--- a/prod/services/wms/ows_refactored/sea_ocean_coast/ows_category_root_cfg.py
+++ b/prod/services/wms/ows_refactored/sea_ocean_coast/ows_category_root_cfg.py
@@ -3,26 +3,41 @@ category_layers = {
     "abstract": "",
     "layers": [
         {
-            "title": "DEA Intertidal (ITEM, NIDEM)",
+            "title": "DEA Intertidal",
             "abstract": "",
             "layers": [
                 {
-                    "include": "ows_refactored.sea_ocean_coast.intertidal.ows_extents_cfg.item_v2_00_layer",
-                    "type": "python",
-                },
-                {
-                    "include": "ows_refactored.sea_ocean_coast.intertidal.ows_extents_cfg.item_v2_00_conf_layer",
-                    "type": "python",
-                },
-                {
-                    "include": "ows_refactored.sea_ocean_coast.intertidal.ows_national_cfg.layer",
+                    # DEA Intertidal Collection 3
+                    "include": "ows_refactored.sea_ocean_coast.intertidal_c3.ows_intertidal_cfg.dea_intertidal_layer",
                     "type": "python",
                 },
             ]
         },
         {
+            # HLTC Collection 2 (nested folder structure is defined below)
             "include": "ows_refactored.sea_ocean_coast.ows_tide_cfg.layers",
             "type": "python",
+        },
+        {
+            "title": "Other",
+            "abstract": "",
+            "layers": [
+                {
+                    # ITEM 2.0 Collection 2
+                    "include": "ows_refactored.sea_ocean_coast.intertidal.ows_extents_cfg.item_v2_00_layer",
+                    "type": "python",
+                },
+                {
+                    # ITEM 2.0 Confidence Collection 2
+                    "include": "ows_refactored.sea_ocean_coast.intertidal.ows_extents_cfg.item_v2_00_conf_layer",
+                    "type": "python",
+                },
+                {
+                    # NIDEM Colllection 2
+                    "include": "ows_refactored.sea_ocean_coast.intertidal.ows_national_cfg.layer",
+                    "type": "python",
+                },
+            ]
         },
     ]
 }


### PR DESCRIPTION
This PR adds DEA Intertidal to prod OWS and the prod section of Terriacube, including a simpler set of three styles (elevation, uncertainty and exposure).

It also updates the prod OWS and prod section of Terriacube to place the older NIDEM and ITEM layers inside "Other".