### PR TITLE
Add DEA Intertidal to DEA Maps

### DIFF
--- a/prod/terria/dea-maps-v8.json
+++ b/prod/terria/dea-maps-v8.json
@@ -1031,111 +1031,36 @@
                             ]
                         },
                         {
-                            "id": "bsRRuv",
+                            "id": "gh567ic",
                             "type": "group",
-                            "name": "DEA Intertidal (ITEM, NIDEM)",
+                            "name": "DEA Intertidal",
                             "members": [
                                 {
                                     "type": "wms",
-                                    "name": "DEA Intertidal Elevation (Landsat)",
-                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "name": "DEA Intertidal (Sentinel-2, Landsat)",
+                                    "url": "https://ows.dea.ga.gov.au/wms",
                                     "opacity": 1,
-                                    "layers": "NIDEM",
+                                    "layers": "ga_s2ls_intertidal_cyear_3",
                                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "NIDEM",
+                                    "linkedWcsCoverage": "ga_s2ls_intertidal_cyear_3",
+                                    "dateFormat": "'Year: 'yyyy",
                                     "leafletUpdateInterval": 750,
                                     "tileErrorHandlingOptions": {
                                         "ignoreUnknownTileErrors": true
                                     },
-                                    "shortReport": "<small>For more information and to download data, visit the <a href='https://knowledge.dea.ga.gov.au/data/product/dea-intertidal-elevation-landsat/'>DEA Intertidal Elevation product description</a></small>",
+                                    "shortReport": "<small>For more information and to download data, visit the <a href='https://knowledge.dea.ga.gov.au/data/product/dea-intertidal/'>DEA Intertidal product description</a></small>",
                                     "featureInfoTemplate": {
-                                        "template": "<div style='width:480px'><h2 style='font-weight:normal'>Digital Earth Australia Intertidal Elevation</h2>Elevation relative to Mean Sea Level (approximately equivelent to AHD): <h1 style='font-weight:normal'><b>{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.nidem}}{{/terria.formatNumber}} metres</b></h1><i>For more information about intertidal mapping accuracy and limitations or to download data, visit the <a href='https://knowledge.dea.ga.gov.au/data/product/dea-intertidal-elevation-landsat/'>DEA Intertidal Elevation product description.</a></i><br/><br/></div>"
+                                        "template": "<div style='width:510px'><h1 style='font-weight:normal'>Digital Earth Australia Intertidal</h1>This location had an elevation above modelled Mean Sea Level (MSL): <h1 style='font-weight:normal'><b>{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.elevation}}{{/terria.formatNumber}} metres (± {{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.elevation_uncertainty}}{{/terria.formatNumber}})</b></h1>It was exposed from tidal inundation for: <h2 style='font-weight:normal'><b>{{data.0.bands.exposure}}%</b> of the <b>{{#terria.formatDateTime}}{format: \"yyyy\"}{{data.0.time}}{{/terria.formatDateTime}}</b> analysis period</h2><hr><br>At this location, satellite data included images of the coast at tide heights from <b>{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.ta_lot}}{{/terria.formatNumber}}</b> to <b>+{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.ta_hot}}{{/terria.formatNumber}}</b> metres above MSL, compared to the full astronomical tide range of <b>{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.ta_lat}}{{/terria.formatNumber}}</b> to <b>+{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.ta_hat}}{{/terria.formatNumber}}</b> metres above MSL.<br><br>This resulted in satellite data observing <b>{{data.0.bands.ta_spread}}%</b> of the astronomical tide range, and failing to observe the lowest <b>{{data.0.bands.ta_offset_low}}%</b> and highest <b>{{data.0.bands.ta_offset_high}}%</b> of tides.<br><br><hr><br><small>For more information about intertidal mapping accuracy and limitations or to download data, visit the <a href='https://docs.dea.ga.gov.au/data/product/dea-intertidal-elevation-landsat/'>DEA Intertidal product description.</a></small><br/><br/></div>"
                                     },
-                                    "id": "bWICtK",
-                                    "shareKeys": [
-                                        "Root Group/Coastal/National Intertidal Digital Elevation Model"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "DEA Intertidal Extents (Landsat)",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "ITEM_V2.0.0",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "ITEM_V2.0.0",
-                                    "leafletUpdateInterval": 750,
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "cXSDLg",
-                                    "shareKeys": [
-                                        "Root Group/Coastal/Intertidal extent model/Intertidal Extent"
-                                    ]
-                                },
-                                {
-                                    "type": "wms",
-                                    "name": "DEA Intertidal Extents confidence",
-                                    "url": "https://ows.dea.ga.gov.au/",
-                                    "opacity": 1,
-                                    "layers": "ITEM_V2.0.0_Conf",
-                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
-                                    "linkedWcsCoverage": "ITEM_V2.0.0_Conf",
-                                    "leafletUpdateInterval": 750,
-                                    "tileErrorHandlingOptions": {
-                                        "ignoreUnknownTileErrors": true
-                                    },
-                                    "id": "6E5V7V",
-                                    "shareKeys": [
-                                        "Root Group/Coastal/Intertidal extent model/Intertidal Extent Confidence"
-                                    ]
+                                    "id": "ghtu564",       
                                 },
                                 {
                                     "type": "geojson",
-                                    "name": "DEA Intertidal Extents polygons for data access",
-                                    "info": [
-                                        {
-                                            "name": "Abstract",
-                                            "content": "The Intertidal Extents Model (ITEM v2.0) product analyses GA's historic archive of satellite imagery to derive a model of the spatial extents of the intertidal zone throughout the tidal cycle. The model can assist in understanding the relative elevation profile of the intertidal zone, delineating exposed areas at differing tidal heights and stages. <p/> The product differs from previous methods used to map the intertidal zone which have been predominately focused on analysing a small number of individual satellite images per location (e.g Ryu et al., 2002; Murray et al., 2012). By utilising a full 30 year time series of observations and a global tidal model (Egbert and Erofeeva, 2002), the methodology enables us to overcome the requirement for clear, high quality observations acquired concurrent to the time of high and low tide."
-                                        },
-                                        {
-                                            "name": "Overview",
-                                            "content": "The Intertidal Extents Model product is a national scale gridded dataset characterising the spatial extents of the exposed intertidal zone, at intervals of the observed tidal range (Sagar et al. 2017). The current version (2.0) utilises all Landsat observations (5, 7, and 8) for Australian coastal regions (excluding off-shore Territories) between 1986 and 2016 (inclusive). <p/> ITEM v2.0 has implemented an improved tidal modelling framework (see Sagar et al. 2018) over that utilised in ITEM v1.0. The expanded Landsat archive within the Digital Earth Australia (DEA) has also enabled the model extent to be increased to cover a number of offshore reefs, including the full Great Barrier Reef and southern sections of the Torres Strait Islands. The DEA archive and new tidal modelling framework has improved the coverage and quality of the ITEM v2.0 relative extents model, particularly in regions where AGDC cell boundaries in ITEM v1.0 produced discontinuities or the imposed v1.0 cell structure resulted in poor quality tidal modelling (see Sagar et al. 2017). <p/> Examples of regions in ITEM v2.0 where these significant improvements have been noted include: <ul> <li>Dampier Peninsula and King Sound, WA. Improved modelling within King Sound has removed the discontinuities seen at cell boundaries in ITEM v1.0, and expanded the extent of intertidal region being mapped. </li> <li>Tiwi Islands, Coburg Peninsula and Croker Island, NT. Poor spatial representation of the regions tidal regimes in ITEM v1.0 has been improved in v2.0 resulting in extensive onshore reefs and mudflats now being mapped. </li> <li>The full Great Barrier Reef has been mapped, detailing reef structures which expose at low tide. Algorithm amendments have reduced the false positive exposed surface detections resulting from glint and sun glitter. </li> <li>Broad Sound, QLD. Improved tidal modelling has resulted in a smoother intertidal extent map, and a greatly improved confidence layer value for the region. </li> <li>Improvements in the coverage of the DEA archive has allowed many regions unresolved in ITEM v1.0 and showing as 'no data' to be modelled successfully in ITEM 2.0. For example, Mornington Island, QLD, Eastern sections of Fraser Island, QLD and peninsulas in Bowling Green Bay National Park near Townsville, QLD</li> </ul>"
-                                        },
-                                        {
-                                            "name": "Accuracy and limitations",
-                                            "content": "Due the sun-synchronous nature of the various Landsat sensor observations; it is unlikely that the full physical extents of the tidal range in any cell will be observed. Hence, terminology has been adopted for the product to reflect the highest modelled tide observed in a given cell (HOT) and the lowest modelled tide observed (LOT) (see Sagar et al. 2017). These measures are relative to Mean Sea Level, and have no consistent relationship to Lowest (LAT) and Highest Astronomical Tide (HAT). <p/> The inclusion of the lowest (LMT) and highest (HMT) modelled tide values for each tidal polygon indicates the highest and lowest tides modelled for that location across the full time series by the OTPS model. The relative difference between the LOT and LMT (and HOT and HMT) heights gives an indication of the extent of the tidal range represented in the Relative Extents Model. <p/> As in ITEM v1.0, v2.0 contains some false positive land detection in open ocean regions. These are a function of the lack of data at the extremes of the observed tidal range, and features like glint and undetected cloud in these data poor regions/intervals. <p/> Methods to isolate and remove these features are in development for future versions. Issues in the DEA archive and data noise in the Esperance, WA region off Cape Le Grande and Cape Arid (Polygons 236,201,301) has resulted in significant artefacts in the model, and use of the model in this area is not recommended. <p/> The Confidence layer is designed to assess the reliability of the Relative Extent Model. Within each tidal range percentile interval, the pixel-based standard deviation of the NDWI values for all observations in the interval subset is calculated. The average standard deviation across all tidal range intervals is then calculated and retained as a quality indicator in this product layer. <p/> The Confidence Layer reflects the pixel based consistency of the NDWI values within each subset of observations, based on the tidal range. Higher standard deviation values indicate water classification changes not based on the tidal cycle, and hence lower confidence in the extent model. <p/> Possible drivers of these changes include: <ol> <li>Inadequacies of the tidal model, due perhaps to complex coastal bathymetry or estuarine structures not captured in the model. These effects have been reduced in ITEM v2.0 compared to previous versions, through the use of an improved tidal modelling framework </li> <li>Change in the structure and exposure of water/non-water features NOT driven by tidal variation. For example, movement of sand banks in estuaries, construction of man-made features (ports etc.).</li> <li>Terrestrial/Inland water features not influenced by the tidal cycle.</li> </ol>"
-                                        },
-                                        {
-                                            "name": "File naming",
-                                            "content": "<h4>THE RELATIVE EXTENTS MODEL v2.0</h4> ITEM_REL_&lt;TIDAL POLYGON NUMBER&gt;_&lt;LONGITUDE&gt;_&lt;LATITUDE&gt; <p/> TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <p/> LONGITUDE is the longitude of the centroid of the tidal polygon <p/> LATITUDE is the latitude of the centroid of the tidal polygon <h4>THE CONFIDENCE LAYER v2.0</h4> ITEM_STD_&lt;TIDAL POLYGON NUMBER&gt;_&lt;LONGITUDE&gt;_&lt;LATITUDE&gt; <p/> TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <p/> LONGITUDE is the longitude of the centroid of the tidal polygon <p/> LATITUDE is the latitude of the centroid of the tidal polygon <p/> The index of downloadable GeoTIFFs can be found here: <p/> <a href='http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalogs/fk4/item_2_0.xml'>http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalogs/fk4/item_2_0.xml</a>"
-                                        },
-                                        {
-                                            "name": "References",
-                                            "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmos. Oceanic Technol. 19, 183–204. <p/> Murray, N.J., Phinn, S.R., Clemens, R.S., Roelfsema, C.M., Fuller, R.A., 2012. Continental Scale Mapping of Tidal Flats across East Asia Using the Landsat Archive. Remote Sensing 4, 3417–3426. <p/> Ryu, J.-H., Won, J.-S., Min, K.D., 2002. Waterline extraction from Landsat TM data in a tidal flat: A case study in Gomso Bay, Korea. Remote Sensing of Environment 83, 442–456. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sensing of Environment 195, 153–169. <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
-                                        }
-                                    ],
-                                    "url": "https://data.dea.ga.gov.au/ITEM_V2/Itemv2.geojson",
-                                    "featureInfoTemplate": {
-                                        "template": "The <b>ITEM v2.0 relative model</b> displays the modelled extents of the exposed intertidal zone, at percentile intervals of the observed tidal range (OTR), derived from Landsat imagery acquired between 1986 and 2016. <p/> The full tidal range at this location is {{LMT}} to {{HMT}} metres relative to mean sea level (MSL), and the OTR at this location is between {{LOT}} and {{HOT}} relative to MSL. <p/> The <b>ITEM v2.0 confidence layer</b> displays the standard deviation of the water index values (NDWI) derived across the tidal intervals used in generating the core ITEM relative product. <p/> High values indicate regions where inundation patterns are not driven by tidal influences. This can be a result of change (shoreline, geomorphic, anthropogenic), or caused by errors in the underlying tidal model. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/ITEM_Intervals/ITEM_REL_{{ID}}_{{lon}}_{{lat}}.jpg'/> <figcaption>Coloured bars corresponding to the legend highlight the observations (black dots) and tidal range used to generate each ITEM interval, compared to the full modelled tidal range (light grey) at this location</figcaption> </figure> <p/> Download the GeoTIFF products for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/ITEM/ITEM_2_0/geotiff/ITEM_REL_{{ID}}_{{lon}}_{{lat}}.tif'>ITEM_REL_{{ID}}_{{lon}}_{{lat}}.tif</a> <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/ITEM/ITEM_2_0/geotiff/ITEM_STD_{{ID}}_{{lon}}_{{lat}}.tif'>ITEM_STD_{{ID}}_{{lon}}_{{lat}}.tif</a>",
-                                        "formats": {
-                                            "lat": {
-                                                "type": "number",
-                                                "minimumFractionDigits": 2
-                                            },
-                                            "lon": {
-                                                "type": "number",
-                                                "minimumFractionDigits": 2
-                                            }
-                                        }
-                                    },
-                                    "id": "6fBRXw",
-                                    "shareKeys": [
-                                        "Root Group/Coastal/Intertidal extent model/Intertidal Extent Polygons data access"
-                                    ]
-                                }
-                            ],
-                            "shareKeys": ["Root Group/Coastal/Intertidal extent model"]
+                                    "name": "DEA Intertidal 32 km tile grid",
+                                    "url": "https://dea-public-data.s3-ap-southeast-2.amazonaws.com/derivative/ga_s2ls_intertidal_cyear_3/ga_summary_grid_c3_32km_coastal.geojson",
+                                    "id": "67ttyU"
+                                },
+                            ]
                         },
                         {
                             "id": "yC2aqy",
@@ -1248,6 +1173,113 @@
                             "shareKeys": [
                                 "Root Group/Coastal/High tide satellite images"
                             ]
+                        },
+                        {
+                            "id": "bsRRuv",
+                            "type": "group",
+                            "name": "Other",
+                            "members": [
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Intertidal Elevation (Landsat)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "NIDEM",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "NIDEM",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "shortReport": "<small>For more information and to download data, visit the <a href='https://knowledge.dea.ga.gov.au/data/product/dea-intertidal-elevation-landsat/'>DEA Intertidal Elevation product description</a></small>",
+                                    "featureInfoTemplate": {
+                                        "template": "<div style='width:480px'><h2 style='font-weight:normal'>Digital Earth Australia Intertidal Elevation</h2>Elevation relative to Mean Sea Level (approximately equivelent to AHD): <h1 style='font-weight:normal'><b>{{#terria.formatNumber}}{maximumFractionDigits:2}{{data.0.bands.nidem}}{{/terria.formatNumber}} metres</b></h1><i>For more information about intertidal mapping accuracy and limitations or to download data, visit the <a href='https://knowledge.dea.ga.gov.au/data/product/dea-intertidal-elevation-landsat/'>DEA Intertidal Elevation product description.</a></i><br/><br/></div>"
+                                    },
+                                    "id": "bWICtK",
+                                    "shareKeys": [
+                                        "Root Group/Coastal/National Intertidal Digital Elevation Model"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Intertidal Extents (Landsat)",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ITEM_V2.0.0",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ITEM_V2.0.0",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "cXSDLg",
+                                    "shareKeys": [
+                                        "Root Group/Coastal/Intertidal extent model/Intertidal Extent"
+                                    ]
+                                },
+                                {
+                                    "type": "wms",
+                                    "name": "DEA Intertidal Extents confidence",
+                                    "url": "https://ows.dea.ga.gov.au/",
+                                    "opacity": 1,
+                                    "layers": "ITEM_V2.0.0_Conf",
+                                    "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
+                                    "linkedWcsCoverage": "ITEM_V2.0.0_Conf",
+                                    "leafletUpdateInterval": 750,
+                                    "tileErrorHandlingOptions": {
+                                        "ignoreUnknownTileErrors": true
+                                    },
+                                    "id": "6E5V7V",
+                                    "shareKeys": [
+                                        "Root Group/Coastal/Intertidal extent model/Intertidal Extent Confidence"
+                                    ]
+                                },
+                                {
+                                    "type": "geojson",
+                                    "name": "DEA Intertidal Extents polygons for data access",
+                                    "info": [
+                                        {
+                                            "name": "Abstract",
+                                            "content": "The Intertidal Extents Model (ITEM v2.0) product analyses GA's historic archive of satellite imagery to derive a model of the spatial extents of the intertidal zone throughout the tidal cycle. The model can assist in understanding the relative elevation profile of the intertidal zone, delineating exposed areas at differing tidal heights and stages. <p/> The product differs from previous methods used to map the intertidal zone which have been predominately focused on analysing a small number of individual satellite images per location (e.g Ryu et al., 2002; Murray et al., 2012). By utilising a full 30 year time series of observations and a global tidal model (Egbert and Erofeeva, 2002), the methodology enables us to overcome the requirement for clear, high quality observations acquired concurrent to the time of high and low tide."
+                                        },
+                                        {
+                                            "name": "Overview",
+                                            "content": "The Intertidal Extents Model product is a national scale gridded dataset characterising the spatial extents of the exposed intertidal zone, at intervals of the observed tidal range (Sagar et al. 2017). The current version (2.0) utilises all Landsat observations (5, 7, and 8) for Australian coastal regions (excluding off-shore Territories) between 1986 and 2016 (inclusive). <p/> ITEM v2.0 has implemented an improved tidal modelling framework (see Sagar et al. 2018) over that utilised in ITEM v1.0. The expanded Landsat archive within the Digital Earth Australia (DEA) has also enabled the model extent to be increased to cover a number of offshore reefs, including the full Great Barrier Reef and southern sections of the Torres Strait Islands. The DEA archive and new tidal modelling framework has improved the coverage and quality of the ITEM v2.0 relative extents model, particularly in regions where AGDC cell boundaries in ITEM v1.0 produced discontinuities or the imposed v1.0 cell structure resulted in poor quality tidal modelling (see Sagar et al. 2017). <p/> Examples of regions in ITEM v2.0 where these significant improvements have been noted include: <ul> <li>Dampier Peninsula and King Sound, WA. Improved modelling within King Sound has removed the discontinuities seen at cell boundaries in ITEM v1.0, and expanded the extent of intertidal region being mapped. </li> <li>Tiwi Islands, Coburg Peninsula and Croker Island, NT. Poor spatial representation of the regions tidal regimes in ITEM v1.0 has been improved in v2.0 resulting in extensive onshore reefs and mudflats now being mapped. </li> <li>The full Great Barrier Reef has been mapped, detailing reef structures which expose at low tide. Algorithm amendments have reduced the false positive exposed surface detections resulting from glint and sun glitter. </li> <li>Broad Sound, QLD. Improved tidal modelling has resulted in a smoother intertidal extent map, and a greatly improved confidence layer value for the region. </li> <li>Improvements in the coverage of the DEA archive has allowed many regions unresolved in ITEM v1.0 and showing as 'no data' to be modelled successfully in ITEM 2.0. For example, Mornington Island, QLD, Eastern sections of Fraser Island, QLD and peninsulas in Bowling Green Bay National Park near Townsville, QLD</li> </ul>"
+                                        },
+                                        {
+                                            "name": "Accuracy and limitations",
+                                            "content": "Due the sun-synchronous nature of the various Landsat sensor observations; it is unlikely that the full physical extents of the tidal range in any cell will be observed. Hence, terminology has been adopted for the product to reflect the highest modelled tide observed in a given cell (HOT) and the lowest modelled tide observed (LOT) (see Sagar et al. 2017). These measures are relative to Mean Sea Level, and have no consistent relationship to Lowest (LAT) and Highest Astronomical Tide (HAT). <p/> The inclusion of the lowest (LMT) and highest (HMT) modelled tide values for each tidal polygon indicates the highest and lowest tides modelled for that location across the full time series by the OTPS model. The relative difference between the LOT and LMT (and HOT and HMT) heights gives an indication of the extent of the tidal range represented in the Relative Extents Model. <p/> As in ITEM v1.0, v2.0 contains some false positive land detection in open ocean regions. These are a function of the lack of data at the extremes of the observed tidal range, and features like glint and undetected cloud in these data poor regions/intervals. <p/> Methods to isolate and remove these features are in development for future versions. Issues in the DEA archive and data noise in the Esperance, WA region off Cape Le Grande and Cape Arid (Polygons 236,201,301) has resulted in significant artefacts in the model, and use of the model in this area is not recommended. <p/> The Confidence layer is designed to assess the reliability of the Relative Extent Model. Within each tidal range percentile interval, the pixel-based standard deviation of the NDWI values for all observations in the interval subset is calculated. The average standard deviation across all tidal range intervals is then calculated and retained as a quality indicator in this product layer. <p/> The Confidence Layer reflects the pixel based consistency of the NDWI values within each subset of observations, based on the tidal range. Higher standard deviation values indicate water classification changes not based on the tidal cycle, and hence lower confidence in the extent model. <p/> Possible drivers of these changes include: <ol> <li>Inadequacies of the tidal model, due perhaps to complex coastal bathymetry or estuarine structures not captured in the model. These effects have been reduced in ITEM v2.0 compared to previous versions, through the use of an improved tidal modelling framework </li> <li>Change in the structure and exposure of water/non-water features NOT driven by tidal variation. For example, movement of sand banks in estuaries, construction of man-made features (ports etc.).</li> <li>Terrestrial/Inland water features not influenced by the tidal cycle.</li> </ol>"
+                                        },
+                                        {
+                                            "name": "File naming",
+                                            "content": "<h4>THE RELATIVE EXTENTS MODEL v2.0</h4> ITEM_REL_&lt;TIDAL POLYGON NUMBER&gt;_&lt;LONGITUDE&gt;_&lt;LATITUDE&gt; <p/> TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <p/> LONGITUDE is the longitude of the centroid of the tidal polygon <p/> LATITUDE is the latitude of the centroid of the tidal polygon <h4>THE CONFIDENCE LAYER v2.0</h4> ITEM_STD_&lt;TIDAL POLYGON NUMBER&gt;_&lt;LONGITUDE&gt;_&lt;LATITUDE&gt; <p/> TIDAL POLYGON NUMBER relates to the id of the tidal polygon referenced by the file <p/> LONGITUDE is the longitude of the centroid of the tidal polygon <p/> LATITUDE is the latitude of the centroid of the tidal polygon <p/> The index of downloadable GeoTIFFs can be found here: <p/> <a href='http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalogs/fk4/item_2_0.xml'>http://dap.nci.org.au/thredds/remoteCatalogService?catalog=http://dapds00.nci.org.au/thredds/catalogs/fk4/item_2_0.xml</a>"
+                                        },
+                                        {
+                                            "name": "References",
+                                            "content": "Egbert, G.D., Erofeeva, S.Y., 2002. Efficient Inverse Modeling of Barotropic Ocean Tides. J. Atmos. Oceanic Technol. 19, 183–204. <p/> Murray, N.J., Phinn, S.R., Clemens, R.S., Roelfsema, C.M., Fuller, R.A., 2012. Continental Scale Mapping of Tidal Flats across East Asia Using the Landsat Archive. Remote Sensing 4, 3417–3426. <p/> Ryu, J.-H., Won, J.-S., Min, K.D., 2002. Waterline extraction from Landsat TM data in a tidal flat: A case study in Gomso Bay, Korea. Remote Sensing of Environment 83, 442–456. <p/> Sagar, S., Roberts, D., Bala, B., Lymburner, L., 2017. Extracting the intertidal extent and topography of the Australian coastline from a 28 year time series of Landsat observations. Remote Sensing of Environment 195, 153–169. <p/> Sagar, S., Phillips, C., Bala, B., Roberts, D., Lymburner, L., 2018. Generating Continental Scale Pixel-Based Surface Reflectance Composites in Coastal Regions with the Use of a Multi-Resolution Tidal Model. Remote Sensing 10, 480."
+                                        }
+                                    ],
+                                    "url": "https://data.dea.ga.gov.au/ITEM_V2/Itemv2.geojson",
+                                    "featureInfoTemplate": {
+                                        "template": "The <b>ITEM v2.0 relative model</b> displays the modelled extents of the exposed intertidal zone, at percentile intervals of the observed tidal range (OTR), derived from Landsat imagery acquired between 1986 and 2016. <p/> The full tidal range at this location is {{LMT}} to {{HMT}} metres relative to mean sea level (MSL), and the OTR at this location is between {{LOT}} and {{HOT}} relative to MSL. <p/> The <b>ITEM v2.0 confidence layer</b> displays the standard deviation of the water index values (NDWI) derived across the tidal intervals used in generating the core ITEM relative product. <p/> High values indicate regions where inundation patterns are not driven by tidal influences. This can be a result of change (shoreline, geomorphic, anthropogenic), or caused by errors in the underlying tidal model. <p/> <figure> <img style='width: 100%' src='http://dea-public-data.s3-ap-southeast-2.amazonaws.com/ITEM_Intervals/ITEM_REL_{{ID}}_{{lon}}_{{lat}}.jpg'/> <figcaption>Coloured bars corresponding to the legend highlight the observations (black dots) and tidal range used to generate each ITEM interval, compared to the full modelled tidal range (light grey) at this location</figcaption> </figure> <p/> Download the GeoTIFF products for this polygon here: <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/ITEM/ITEM_2_0/geotiff/ITEM_REL_{{ID}}_{{lon}}_{{lat}}.tif'>ITEM_REL_{{ID}}_{{lon}}_{{lat}}.tif</a> <p/> <a href='http://dapds00.nci.org.au/thredds/fileServer/fk4/datacube/002/ITEM/ITEM_2_0/geotiff/ITEM_STD_{{ID}}_{{lon}}_{{lat}}.tif'>ITEM_STD_{{ID}}_{{lon}}_{{lat}}.tif</a>",
+                                        "formats": {
+                                            "lat": {
+                                                "type": "number",
+                                                "minimumFractionDigits": 2
+                                            },
+                                            "lon": {
+                                                "type": "number",
+                                                "minimumFractionDigits": 2
+                                            }
+                                        }
+                                    },
+                                    "id": "6fBRXw",
+                                    "shareKeys": [
+                                        "Root Group/Coastal/Intertidal extent model/Intertidal Extent Polygons data access"
+                                    ]
+                                }
+                            ],
+                            "shareKeys": ["Root Group/Coastal/Intertidal extent model"]
                         }
                     ],
                     "shareKeys": ["Root Group/Coastal", "Root Group/Sea, ocean and coastline", "Root Group/Sea, ocean and coast"]


### PR DESCRIPTION
This PR adds the new DEA Intertidal layers to DEA Maps. 

Test using the "DEA Maps preview" link below: "Explore data > Sea, ocean and coast > DEA Intertidal > DEA Intertidal (Sentinel-2, Landsat)"