### PR TITLE
Intertidal add data link

### DIFF
--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -3147,7 +3147,7 @@
                                 {
                                     "type": "geojson",
                                     "name": "DEA Intertidal 32 km tile grid",
-                                    "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_s2ls_intertidal_cyear_3/ga_summary_grid_c3_32km_coastal.geojson",
+                                    "url": "https://data.dea.ga.gov.au/derivative/ga_s2ls_intertidal_cyear_3/ga_summary_grid_c3_32km_coastal_prod.geojson",
                                     "id": "67ttyU"
                                 },
                             ]

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -1106,7 +1106,7 @@
                                 {
                                     "type": "geojson",
                                     "name": "DEA Intertidal 32 km tile grid",
-                                    "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_s2ls_intertidal_cyear_3/ga_summary_grid_c3_32km_coastal.geojson",
+                                    "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_s2ls_intertidal_cyear_3/ga_summary_grid_c3_32km_coastal_dev.geojson",
                                     "id": "gtBB45t"
                                 },
                             ]

--- a/prod/terria/dea-maps-v8.json
+++ b/prod/terria/dea-maps-v8.json
@@ -1057,7 +1057,7 @@
                                 {
                                     "type": "geojson",
                                     "name": "DEA Intertidal 32 km tile grid",
-                                    "url": "https://dea-public-data.s3-ap-southeast-2.amazonaws.com/derivative/ga_s2ls_intertidal_cyear_3/ga_summary_grid_c3_32km_coastal.geojson",
+                                    "url": "https://data.dea.ga.gov.au/derivative/ga_s2ls_intertidal_cyear_3/ga_summary_grid_c3_32km_coastal_prod.geojson",
                                     "id": "67ttyU"
                                 },
                             ]


### PR DESCRIPTION
 
DEA Intertidal grid in both dev and prod now point to new geojsons with an additional data access field which points to the tile's data on S3.

On dev it points to the tile's data on dev.
On prod it points to the tile's data on prod.

https://maps.dea.ga.gov.au/#clean&https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/intertidal_add_data_link/prod/terria/dea-maps-v8.json
 
https://terria-cube.terria.io/#clean&https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/intertidal_add_data_link/dev/terria/terria-cube-v8.json
