### PR TITLE
Update the FC Percentile product configuration in the dev environment.

### DIFF
--- a/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
+++ b/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
@@ -11,7 +11,7 @@ plugin_config:
 product:
   name: ga_ls_fc_pc_cyear_3
   short_name: ga_ls_fc_pc_cyear_3
-  version: 3.0.1
+  version: 3.1.0
   product_family: fc_percentile
 
   # -- EO Dataset3 relative section --
@@ -87,7 +87,7 @@ dataset_filters: >-
   {"datetime": "1987-01--P17Y"}|{"datetime": "2004-01--P6Y", "eo:platform": "landsat-5"}|
   {"datetime": "2010-01--P3Y"}|{"datetime": "2013-01--P5M"}|{"eo:platform": "landsat-8"}
 output_location: >-
-  s3://dea-public-data-dev/derivative/ga_ls_fc_pc_cyear_3/3-0-1
+  s3://dea-public-data-dev/derivative/ga_ls_fc_pc_cyear_3/3-1-0
 
 # save-tasks options
 input_products: ga_ls_fc_3+ga_ls_wo_3

--- a/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
+++ b/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
@@ -88,7 +88,7 @@ dataset_filters: >-
   {"datetime": "2010-01--P3Y"}|{"datetime": "2013-01--P5M"}|{"eo:platform": "landsat-8"}|
   {"eo:platform": "landsat-9"}
 output_location: >-
-  s3://dea-public-data-dev/tebadi-tests/derivative/ga_ls_fc_pc_cyear_3/4-0-1
+  s3://dea-public-data-dev/test/derivative/ga_ls_fc_pc_cyear_3/4-0-1
 
 # save-tasks options
 input_products: ga_ls_fc_3+ga_ls_wo_3

--- a/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
+++ b/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
@@ -85,7 +85,8 @@ cog_opts:
 apply_eodatasets3: True
 dataset_filters: >-
   {"datetime": "1987-01--P17Y"}|{"datetime": "2004-01--P6Y", "eo:platform": "landsat-5"}|
-  {"datetime": "2010-01--P3Y"}|{"datetime": "2013-01--P5M"}|{"eo:platform": "landsat-8"}|{"eo:platform": "landsat-9"}
+  {"datetime": "2010-01--P3Y"}|{"datetime": "2013-01--P5M"}|{"eo:platform": "landsat-8"}|
+  {"eo:platform": "landsat-9"}
 output_location: >-
   s3://dea-public-data-dev/tebadi-tests/derivative//4-0-1
 

--- a/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
+++ b/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
@@ -11,7 +11,7 @@ plugin_config:
 product:
   name: ga_ls_fc_pc_cyear_3
   short_name: ga_ls_fc_pc_cyear_3
-  version: 3.1.0
+  version: 4.0.1
   product_family: fc_percentile
 
   # -- EO Dataset3 relative section --
@@ -85,9 +85,9 @@ cog_opts:
 apply_eodatasets3: True
 dataset_filters: >-
   {"datetime": "1987-01--P17Y"}|{"datetime": "2004-01--P6Y", "eo:platform": "landsat-5"}|
-  {"datetime": "2010-01--P3Y"}|{"datetime": "2013-01--P5M"}|{"eo:platform": "landsat-8"}
+  {"datetime": "2010-01--P3Y"}|{"datetime": "2013-01--P5M"}|{"eo:platform": "landsat-8"}|{"eo:platform": "landsat-9"}
 output_location: >-
-  s3://dea-public-data-dev/derivative/ga_ls_fc_pc_cyear_3/3-1-0
+  s3://dea-public-data-dev/tebadi-tests/derivative//4-0-1
 
 # save-tasks options
 input_products: ga_ls_fc_3+ga_ls_wo_3

--- a/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
+++ b/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
@@ -88,7 +88,7 @@ dataset_filters: >-
   {"datetime": "2010-01--P3Y"}|{"datetime": "2013-01--P5M"}|{"eo:platform": "landsat-8"}|
   {"eo:platform": "landsat-9"}
 output_location: >-
-  s3://dea-public-data-dev/tebadi-tests/derivative//4-0-1
+  s3://dea-public-data-dev/tebadi-tests/derivative/ga_ls_fc_pc_cyear_3/4-0-1
 
 # save-tasks options
 input_products: ga_ls_fc_3+ga_ls_wo_3

--- a/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
+++ b/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml
@@ -2,16 +2,16 @@ plugin: fc-percentiles # this can help system find the relative plugin and plugi
 plugin_config:
   cloud_filters:
     cloud:
-      - [dilation, 5]
+      - [dilation, 6]
     cloud_shadow:
-      - [dilation, 10]
+      - [dilation, 6]
   transform_code: EPSG:9688
   area_of_interest: [-180, -90, 180, 90] # accommodate the fact of 326xx not intersecting 3577 in LS
 
 product:
   name: ga_ls_fc_pc_cyear_3
   short_name: ga_ls_fc_pc_cyear_3
-  version: 3.0.0
+  version: 3.0.1
   product_family: fc_percentile
 
   # -- EO Dataset3 relative section --
@@ -87,9 +87,9 @@ dataset_filters: >-
   {"datetime": "1987-01--P17Y"}|{"datetime": "2004-01--P6Y", "eo:platform": "landsat-5"}|
   {"datetime": "2010-01--P3Y"}|{"datetime": "2013-01--P5M"}|{"eo:platform": "landsat-8"}
 output_location: >-
-  s3://dea-public-data-dev/derivative/ga_ls_fc_pc_cyear_3/3-0-0
+  s3://dea-public-data-dev/derivative/ga_ls_fc_pc_cyear_3/3-0-1
 
 # save-tasks options
 input_products: ga_ls_fc_3+ga_ls_wo_3
 frequency: annual
-grid: au-30
+grid: au_extended_30


### PR DESCRIPTION
This PR updates the FC Percentile product configuration in the dev in preparation for applying cloud and shadow buffer as well as including the LS9 FC data. The FCP version has been update from 3.0.0 to 3.1.0 since the algorithm hasn't changed.