### PR TITLE
Add expanded grid to Terria and DEA Maps

### DIFF
--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -1820,10 +1820,10 @@
                                     "info": [
                                         {
                                             "name": "Important information",
-                                            "content": "This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by updating region code IDs to account for new satellite data processed over Australia's external territories."
+                                            "content": "This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> in 2024 by updating region code IDs to account for new satellite data processed over Australia's external territories."
                                         }
                                     ],
-                                    "shortReport": "<small><b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by updating region code IDs to account for new satellite data processed over Australia's external territories.</small>",
+                                    "shortReport": "<small><b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> in 2024 by updating region code IDs to account for new satellite data processed over Australia's external territories.</small>",
                                     "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_summary_grid_c3_expanded.geojson",
                                     "id": "tu8951"
                                 },

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -1816,6 +1816,13 @@
                                 },
                                 {
                                     "type": "geojson",
+                                    "name": "DEA Summary Product Grid (Collection 3, expanded)",
+                                    "shortReport": "<small>This is an <b>experimental</b> layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories.</small>",
+                                    "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_summary_grid_c3_expanded.geojson",
+                                    "id": "tu8951"
+                                },
+                                {
+                                    "type": "geojson",
                                     "name": "DEA Summary Product Grid (Collection 3)",
                                     "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_summary_grid_c3.geojson",
                                     "id": "GJY53s"

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -1817,7 +1817,13 @@
                                 {
                                     "type": "geojson",
                                     "name": "DEA Summary Product Grid (Collection 3, expanded)",
-                                    "shortReport": "<small>This is an <b>experimental</b> layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories.</small>",
+                                    "info": [
+                                        {
+                                            "name": "Important information",
+                                            "content": "<b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories."
+                                        }
+                                    ],
+                                    "shortReport": "<small><b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories.</small>",
                                     "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_summary_grid_c3_expanded.geojson",
                                     "id": "tu8951"
                                 },

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -1820,10 +1820,10 @@
                                     "info": [
                                         {
                                             "name": "Important information",
-                                            "content": "This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories."
+                                            "content": "This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by updating region code IDs to account for new satellite data processed over Australia's external territories."
                                         }
                                     ],
-                                    "shortReport": "<small><b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories.</small>",
+                                    "shortReport": "<small><b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by updating region code IDs to account for new satellite data processed over Australia's external territories.</small>",
                                     "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_summary_grid_c3_expanded.geojson",
                                     "id": "tu8951"
                                 },

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -1820,7 +1820,7 @@
                                     "info": [
                                         {
                                             "name": "Important information",
-                                            "content": "<b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories."
+                                            "content": "This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories."
                                         }
                                     ],
                                     "shortReport": "<small><b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories.</small>",

--- a/prod/terria/dea-maps-v8.json
+++ b/prod/terria/dea-maps-v8.json
@@ -1361,10 +1361,10 @@
                                     "info": [
                                         {
                                             "name": "Important information",
-                                            "content": "This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by updating region code IDs to account for new satellite data processed over Australia's external territories."
+                                            "content": "This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> in 2024 by updating region code IDs to account for new satellite data processed over Australia's external territories."
                                         }
                                     ],
-                                    "shortReport": "<small><b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by updating region code IDs to account for new satellite data processed over Australia's external territories.</small>",
+                                    "shortReport": "<small><b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> in 2024 by updating region code IDs to account for new satellite data processed over Australia's external territories.</small>",
                                     "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_summary_grid_c3_expanded.geojson",
                                     "id": "ui8151"
                                 },

--- a/prod/terria/dea-maps-v8.json
+++ b/prod/terria/dea-maps-v8.json
@@ -1361,7 +1361,7 @@
                                     "info": [
                                         {
                                             "name": "Important information",
-                                            "content": "<b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories."
+                                            "content": "This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories."
                                         }
                                     ],
                                     "shortReport": "<small><b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories.</small>",

--- a/prod/terria/dea-maps-v8.json
+++ b/prod/terria/dea-maps-v8.json
@@ -1357,6 +1357,13 @@
                                 },
                                 {
                                     "type": "geojson",
+                                    "name": "DEA Summary Product Grid (Collection 3, expanded)",
+                                    "shortReport": "<small>This is an <b>experimental</b> layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories.</small>",
+                                    "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_summary_grid_c3_expanded.geojson",
+                                    "id": "ui8151"
+                                },
+                                {
+                                    "type": "geojson",
                                     "name": "DEA Summary Product Grid (Collection 3)",
                                     "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_summary_grid_c3.geojson",
                                     "id": "xss124"

--- a/prod/terria/dea-maps-v8.json
+++ b/prod/terria/dea-maps-v8.json
@@ -1358,7 +1358,13 @@
                                 {
                                     "type": "geojson",
                                     "name": "DEA Summary Product Grid (Collection 3, expanded)",
-                                    "shortReport": "<small>This is an <b>experimental</b> layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories.</small>",
+                                    "info": [
+                                        {
+                                            "name": "Important information",
+                                            "content": "<b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories."
+                                        }
+                                    ],
+                                    "shortReport": "<small><b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories.</small>",
                                     "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_summary_grid_c3_expanded.geojson",
                                     "id": "ui8151"
                                 },

--- a/prod/terria/dea-maps-v8.json
+++ b/prod/terria/dea-maps-v8.json
@@ -1361,10 +1361,10 @@
                                     "info": [
                                         {
                                             "name": "Important information",
-                                            "content": "This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories."
+                                            "content": "This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by updating region code IDs to account for new satellite data processed over Australia's external territories."
                                         }
                                     ],
-                                    "shortReport": "<small><b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by expanding it to encompass new satellite data processed over Australia's external territories.</small>",
+                                    "shortReport": "<small><b>Note:</b> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by updating region code IDs to account for new satellite data processed over Australia's external territories.</small>",
                                     "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_summary_grid_c3_expanded.geojson",
                                     "id": "ui8151"
                                 },


### PR DESCRIPTION
This PR adds a GeoJSON version of the updated/expanded Collection 3 grid to Terriacube and DEA Maps (see preview links below). It is located in `Other > DEA Shapes`.

To make it clear that the grid is not final and may change, I have included the following caveat:

> This is a provisional layer intended to replace the existing <b>DEA Summary Product Grid (Collection 3)</b> by updating region code IDs to account for new satellite data processed over Australia's external territories.

![image](https://github.com/GeoscienceAustralia/dea-config/assets/17680388/83df4e40-6091-475f-a6c0-9ce0a0da2b5a)
