### PR TITLE
Fix island masking bug

### DIFF
--- a/.github/workflows/ows_cfg_testing_dev.yaml
+++ b/.github/workflows/ows_cfg_testing_dev.yaml
@@ -28,10 +28,10 @@ jobs:
 
     - name: Run ows_refactored_cfg test (dev)
       run: |
-        docker-compose -f docker-compose.ows.yaml up -d
-        docker-compose -f docker-compose.ows.yaml exec -T ows /bin/sh -c "datacube system init"
-        docker-compose -f docker-compose.ows.yaml exec -T ows /bin/sh -c "cd /dea-config; ./compare-cfg.sh"
-        docker-compose -f docker-compose.ows.yaml down
+        docker compose -f docker-compose.ows.yaml up -d
+        docker compose -f docker-compose.ows.yaml exec -T ows /bin/sh -c "datacube system init"
+        docker compose -f docker-compose.ows.yaml exec -T ows /bin/sh -c "cd /dea-config; ./compare-cfg.sh"
+        docker compose -f docker-compose.ows.yaml down
       env:
         OWS_CFG_PATH: dev/services/wms/ows_refactored
         PYTHON_PATH: dev/services/wms/

--- a/.github/workflows/ows_cfg_testing_prod.yaml
+++ b/.github/workflows/ows_cfg_testing_prod.yaml
@@ -29,10 +29,10 @@ jobs:
 
     - name: Run ows_refactored_cfg test (Prod)
       run: |
-        docker-compose -f docker-compose.ows.yaml up -d
-        docker-compose -f docker-compose.ows.yaml exec -T ows /bin/sh -c "datacube system init"
-        docker-compose -f docker-compose.ows.yaml exec -T ows /bin/sh -c "cd /dea-config; ./compare-cfg.sh"
-        docker-compose -f docker-compose.ows.yaml down
+        docker compose -f docker-compose.ows.yaml up -d
+        docker compose -f docker-compose.ows.yaml exec -T ows /bin/sh -c "datacube system init"
+        docker compose -f docker-compose.ows.yaml exec -T ows /bin/sh -c "cd /dea-config; ./compare-cfg.sh"
+        docker compose -f docker-compose.ows.yaml down
       env:
         OWS_CFG_PATH: prod/services/wms/ows_refactored
         PYTHON_PATH: prod/services/wms/

--- a/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/style_c3_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/style_c3_cfg.py
@@ -11,7 +11,7 @@ pq_mask_fmask_land = [
     {
         "band": "land",
         "invert": True,
-        "values": [1],
+        "values": [0],
     }
 ]
 


### PR DESCRIPTION
The `geodata_coast_100k layer` ([used to define "land" in our ARD styles](https://github.com/GeoscienceAustralia/dea-config/blob/master/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/ows_c3_cfg.py#L181-L184)) has values of 0 (water), 1 (islands) and 2 (land):
![image](https://github.com/user-attachments/assets/0c121cd3-fe52-466f-b958-3f355b06abf1)

But for some reason, the `pq_mask_fmask_land` mask seems to be using [a value of 1 and then inverting it](https://github.com/GeoscienceAustralia/dea-config/blob/master/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/style_c3_cfg.py#L12-L14)... which seems to be leading to islands being masked but water and land being preserved.
 
This PR attempts to fix this by [to change this line to](https://github.com/GeoscienceAustralia/dea-config/blob/master/dev/services/wms/ows_refactored/baseline_satellite_data/landsat/style_c3_cfg.py#L14) `[0]`, i.e. water, which should lead to ocean being masked but not land or islands.