### PR TITLE
Fix masking in remaining ARD styles

### DIFF
--- a/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/style_s2_cfg.py
+++ b/dev/services/wms/ows_refactored/baseline_satellite_data/sentinel2/style_s2_cfg.py
@@ -14,7 +14,7 @@ s2_cloudless_mask = [
     {
         "band": "land",
         "invert": True,
-        "values": [1],
+        "values": [0],
     }
 ]
 

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/landsat/style_c3_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/landsat/style_c3_cfg.py
@@ -11,7 +11,7 @@ pq_mask_fmask_land = [
     {
         "band": "land",
         "invert": True,
-        "values": [1],
+        "values": [0],
     }
 ]
 

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/landsat_s2_combined/style_combined_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/landsat_s2_combined/style_combined_cfg.py
@@ -11,7 +11,7 @@ pq_mask_fmask_land = [
     {
         "band": "land",
         "invert": True,
-        "values": [1],
+        "values": [0],
     }
 ]
 

--- a/prod/services/wms/ows_refactored/baseline_satellite_data/sentinel2/style_s2_cfg.py
+++ b/prod/services/wms/ows_refactored/baseline_satellite_data/sentinel2/style_s2_cfg.py
@@ -14,7 +14,7 @@ s2_cloudless_mask = [
     {
         "band": "land",
         "invert": True,
-        "values": [1],
+        "values": [0],
     }
 ]
 


### PR DESCRIPTION
Have updated:

- Dev Sentinel-2 layer
- Prod Landsat layer
- Prod Sentinel-2 layer
- Prod combined layer

Dev WMS combined style is old and does not apply masking - we should fix this but not in this PR