### PR TITLE
Delete the ACL as bucket policy is enforced in the prod account.

### DIFF
--- a/prod/services/odc-stats/mangroves/ga_ls_mangrove_cover_cyear_3.yaml
+++ b/prod/services/odc-stats/mangroves/ga_ls_mangrove_cover_cyear_3.yaml
@@ -49,7 +49,7 @@ max_processing_time: 1200
 job_queue_max_lease: 300
 renew_safety_margin: 60
 future_poll_interval: 2
-s3_acl: public-read
+
 # Generic product attributes
 cog_opts:
   zlevel: 9


### PR DESCRIPTION
The object ownership in the public data account has now changed to "bucket owner enforced" so its no longer needed to define ACL for objects in this bucket.