### PR TITLE
S3 ACL removal

### DIFF
--- a/prod/services/odc-stats/wofs_summary/ga_ls_wo_fq_apr_oct_3.yaml
+++ b/prod/services/odc-stats/wofs_summary/ga_ls_wo_fq_apr_oct_3.yaml
@@ -106,7 +106,7 @@ max_processing_time: 1200
 job_queue_max_lease: 300
 renew_safety_margin: 60
 future_poll_interval: 2
-s3_acl: public-read
+
 # Generic product attributes
 cog_opts:
   zlevel: 9
@@ -116,5 +116,4 @@ output_location: >-
 
 # save-tasks options
 input_products: ga_ls_wo_3
-frequency: apr-oct
 grid: au_extended_30

--- a/prod/services/odc-stats/wofs_summary/ga_ls_wo_fq_cyear_3.yaml
+++ b/prod/services/odc-stats/wofs_summary/ga_ls_wo_fq_cyear_3.yaml
@@ -107,7 +107,7 @@ max_processing_time: 1200
 job_queue_max_lease: 300
 renew_safety_margin: 60
 future_poll_interval: 2
-s3_acl: public-read
+
 # Generic product attributes
 cog_opts:
   zlevel: 9

--- a/prod/services/odc-stats/wofs_summary/ga_ls_wo_fq_fyear_3.yaml
+++ b/prod/services/odc-stats/wofs_summary/ga_ls_wo_fq_fyear_3.yaml
@@ -107,7 +107,7 @@ max_processing_time: 1200
 job_queue_max_lease: 300
 renew_safety_margin: 60
 future_poll_interval: 2
-s3_acl: public-read
+
 # Generic product attributes
 cog_opts:
   zlevel: 9

--- a/prod/services/odc-stats/wofs_summary/ga_ls_wo_fq_myear_3.yaml
+++ b/prod/services/odc-stats/wofs_summary/ga_ls_wo_fq_myear_3.yaml
@@ -104,7 +104,7 @@ max_processing_time: 1200
 job_queue_max_lease: 300
 renew_safety_margin: 60
 future_poll_interval: 2
-s3_acl: public-read
+
 # Generic product attributes
 cog_opts:
   zlevel: 9

--- a/prod/services/odc-stats/wofs_summary/ga_ls_wo_fq_nov_mar_3.yaml
+++ b/prod/services/odc-stats/wofs_summary/ga_ls_wo_fq_nov_mar_3.yaml
@@ -106,7 +106,7 @@ max_processing_time: 1200
 job_queue_max_lease: 300
 renew_safety_margin: 60
 future_poll_interval: 2
-s3_acl: public-read
+
 # Generic product attributes
 cog_opts:
   zlevel: 9


### PR DESCRIPTION
No longer required.  s3 ACLs removed from use in destination location