### PR TITLE
Correct colours

### DIFF
--- a/dev/services/wms/ows_refactored/land_and_vegetation/landcover/ows_c3_lc_cyear_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/landcover/ows_c3_lc_cyear_cfg.py
@@ -31,8 +31,8 @@ style_c3_level4_lifeform = {
     "value_map": {
         "level4": [
             {'title': "", 'abstract': "", 'values': [255], 'color': '#FFFFFF', 'alpha': 0},
-            {'title': "Woody", 'abstract': "", 'values': [2, 20, 38, 56], 'color': '#0E7912', 'alpha': 1},
-            {'title': "Herbaceous", 'abstract': "", 'values': [3, 21, 39, 57], 'color': '#77A71E', 'alpha': 1}
+            {'title': "Woody", 'abstract': "", 'values': [2, 9, 10, 11, 12, 13, 20, 27, 28, 29, 30, 31, 38, 45, 46, 47, 48, 49, 56, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77], 'color': '#0E7912', 'alpha': 1},
+            {'title': "Herbaceous", 'abstract': "", 'values': [3, 14, 15, 16, 17, 18, 21, 32, 33, 34, 35, 36, 39, 50, 51, 52, 53, 54, 57, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92], 'color': '#77A71E', 'alpha': 1}
         ]
     },
 }

--- a/prod/services/wms/ows_refactored/land_and_vegetation/landcover/ows_c3_lc_cyear_cfg.py
+++ b/prod/services/wms/ows_refactored/land_and_vegetation/landcover/ows_c3_lc_cyear_cfg.py
@@ -31,8 +31,8 @@ style_c3_level4_lifeform = {
     "value_map": {
         "level4": [
             {'title': "", 'abstract': "", 'values': [255], 'color': '#FFFFFF', 'alpha': 0},
-            {'title': "Woody", 'abstract': "", 'values': [2, 20, 38, 56], 'color': '#0E7912', 'alpha': 1},
-            {'title': "Herbaceous", 'abstract': "", 'values': [3, 21, 39, 57], 'color': '#77A71E', 'alpha': 1}
+            {'title': "Woody", 'abstract': "", 'values': [2, 9, 10, 11, 12, 13, 20, 27, 28, 29, 30, 31, 38, 45, 46, 47, 48, 49, 56, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77], 'color': '#0E7912', 'alpha': 1},
+            {'title': "Herbaceous", 'abstract': "", 'values': [3, 14, 15, 16, 17, 18, 21, 32, 33, 34, 35, 36, 39, 50, 51, 52, 53, 54, 57, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92], 'color': '#77A71E', 'alpha': 1}
         ]
     },
 }


### PR DESCRIPTION
this PR is to correct the lifeform colour scheme. Now all woody and all herbaceous classes are included in the corresponding lifeform classes.
I also quickly checked the other descriptors, they seem to include all the correct lcasses