### PR TITLE
Trial adding custom metadata to DEA Intertidal FeatureInfo

### DIFF
--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
@@ -163,6 +163,9 @@ style_intertidal_elevation_adaptive = {
             "hot": "ta_hot",
         },
     },
+    "custom_includes": {
+        "tide_graph_path": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.tide_graph_path",  # add custom metadata field
+    },
     "multi_date": [
         {
             "allowed_count_range": [2, 2],

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
@@ -53,3 +53,18 @@ def multi_date_raw_elevation(data, band, band_mapper=None):
     data1, data2 = (data.sel(time=dt) for dt in data.coords["time"].values)
 
     return data2[band] - data1[band]
+
+
+def tide_graph_path(data, ds):
+    """
+    Calculates an additional metadata field providing the URL
+    to a graph that is used to visualise tide biases in DEA Intertidal
+    """
+
+    # Extract required data from datacube dataset
+    version = ds.metadata_doc['properties']['odc:dataset_version'].replace(".", "-")
+    year = ds.metadata_doc['properties']['datetime'][:4]
+    region = ds.metadata_doc['properties']['odc:region_code'].replace("y", "/y")
+
+    # Combine into a string
+    return f"https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_s2ls_intertidal_cyear_3/{version}/{region}/{year}--P1Y/tide_graph.png"


### PR DESCRIPTION
This PR tests out adding a custom metadata field to our DEA Intertidal FeatureInfo table, using new `custom_includes` functionality added by @SpacemanPaul last year:
https://github.com/opendatacube/datacube-ows/pull/1039/
https://datacube-ows.readthedocs.io/en/latest/cfg_layers.html#custom-layer-includes-custom-includes

This will hopefully allow us to point to a specific S3 path, generated by combining metadata fields from the dataset being viewed, e.g.:
`f"https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_s2ls_intertidal_cyear_3/{version}/{region}/{year}--P1Y/tide_graph.png"`
https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_s2ls_intertidal_cyear_3/1-0-0/x137/y175/2022--P1Y/tide_graph.png