### PR TITLE
Experimental tidal composite OWS updates

### DIFF
--- a/dev/services/wms/inventory.json
+++ b/dev/services/wms/inventory.json
@@ -712,9 +712,9 @@
                 "high_false",
                 "low_mndwi",
                 "high_mndwi",
+                "count_clear",
                 "low_true_log",
-                "high_true_log",
-                "count_clear"
+                "high_true_log"
             ]
         },
         {

--- a/dev/services/wms/inventory.json
+++ b/dev/services/wms/inventory.json
@@ -704,7 +704,7 @@
             "product": [
                 "ga_s2_tidal_composites_cyear_3"
             ],
-            "styles_count": 7,
+            "styles_count": 9,
             "styles_list": [
                 "low_true",
                 "high_true",
@@ -712,6 +712,8 @@
                 "high_false",
                 "low_mndwi",
                 "high_mndwi",
+                "low_true_log",
+                "high_true_log",
                 "count_clear"
             ]
         },

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/ows_tidal_composites_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/ows_tidal_composites_cfg.py
@@ -13,6 +13,8 @@ bands_tidal_composites = {
     "high_blue": [],
     "high_swir_2": [],
     "high_nir_1": [],
+    "qa_low_threshold": [],
+    "qa_high_threshold": [],
     "qa_count_clear": [],
 }
 

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/style_tidal_composites_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/style_tidal_composites_cfg.py
@@ -125,6 +125,7 @@ style_low_true_log = {
     "name": "low_true_log",
     "title": "True colour – Low tide (experimental)",
     "abstract": "Low tide true colour image, using the red, green and blue bands",
+    "needed_bands": ["low_red", "low_green", "low_blue"],
     "components": {
         "red": {
             "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
@@ -157,6 +158,7 @@ style_high_true_log = {
     "name": "high_true_log",
     "title": "True colour – High tide (experimental)",
     "abstract": "High tide true colour image, using the red, green and blue bands",
+    "needed_bands": ["high_red", "high_green", "high_blue"],
     "components": {
         "red": {
             "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/style_tidal_composites_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/style_tidal_composites_cfg.py
@@ -125,7 +125,7 @@ style_low_true_log = {
     "name": "low_true_log",
     "title": "True colour – Low tide (experimental)",
     "abstract": "Low tide true colour image, using the red, green and blue bands",
-    "needed_bands": ["low_red", "low_green", "low_blue"],
+    "additional_bands": ["low_red", "low_green", "low_blue"],
     "components": {
         "red": {
             "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
@@ -158,7 +158,7 @@ style_high_true_log = {
     "name": "high_true_log",
     "title": "True colour – High tide (experimental)",
     "abstract": "High tide true colour image, using the red, green and blue bands",
-    "needed_bands": ["high_red", "high_green", "high_blue"],
+    "additional_bands": ["high_red", "high_green", "high_blue"],
     "components": {
         "red": {
             "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/style_tidal_composites_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/style_tidal_composites_cfg.py
@@ -127,7 +127,7 @@ style_low_true_log = {
     "abstract": "Low tide true colour image, using the red, green and blue bands",
     "components": {
         "red": {
-            "function": log_scaling,
+            "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
             "kwargs": {
                 "band": "low_red",
                 "scale_from": (2.5, 3.30),
@@ -135,7 +135,7 @@ style_low_true_log = {
             }
         },
         "green": {
-            "function": log_scaling,
+            "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
             "kwargs": {
                 "band": "low_green",
                 "scale_from": (2.5, 3.30),
@@ -143,7 +143,7 @@ style_low_true_log = {
             }
         },
         "blue": {
-            "function": log_scaling,
+            "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
             "kwargs": {
                 "band": "low_blue",
                 "scale_from": (2.5, 3.30),
@@ -159,7 +159,7 @@ style_high_true_log = {
     "abstract": "High tide true colour image, using the red, green and blue bands",
     "components": {
         "red": {
-            "function": log_scaling,
+            "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
             "kwargs": {
                 "band": "high_red",
                 "scale_from": (2.5, 3.38),
@@ -167,7 +167,7 @@ style_high_true_log = {
             }
         },
         "green": {
-            "function": log_scaling,
+            "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
             "kwargs": {
                 "band": "high_green",
                 "scale_from": (2.5, 3.38),
@@ -175,7 +175,7 @@ style_high_true_log = {
             }
         },
         "blue": {
-            "function": log_scaling,
+            "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
             "kwargs": {
                 "band": "high_blue",
                 "scale_from": (2.5, 3.38),
@@ -194,6 +194,6 @@ styles_tidal_composites_list = [
     style_low_mndwi,
     style_high_mndwi,
     style_count_clear,
-    low_true_log,
-    high_true_log,
+    style_low_true_log,
+    style_high_true_log,
 ]

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/style_tidal_composites_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/style_tidal_composites_cfg.py
@@ -121,6 +121,70 @@ style_count_clear = {
     },
 }
 
+style_low_true_log = {
+    "name": "low_true_log",
+    "title": "True colour – Low tide (experimental)",
+    "abstract": "Low tide true colour image, using the red, green and blue bands",
+    "components": {
+        "red": {
+            "function": log_scaling,
+            "kwargs": {
+                "band": "low_red",
+                "scale_from": (2.5, 3.30),
+                "scale_to": (0, 255)
+            }
+        },
+        "green": {
+            "function": log_scaling,
+            "kwargs": {
+                "band": "low_green",
+                "scale_from": (2.5, 3.30),
+                "scale_to": (0, 255)
+            }
+        },
+        "blue": {
+            "function": log_scaling,
+            "kwargs": {
+                "band": "low_blue",
+                "scale_from": (2.5, 3.30),
+                "scale_to": (0, 255)
+            }
+        },
+    },
+}
+
+style_high_true_log = {
+    "name": "high_true_log",
+    "title": "True colour – High tide (experimental)",
+    "abstract": "High tide true colour image, using the red, green and blue bands",
+    "components": {
+        "red": {
+            "function": log_scaling,
+            "kwargs": {
+                "band": "high_red",
+                "scale_from": (2.5, 3.38),
+                "scale_to": (0, 255)
+            }
+        },
+        "green": {
+            "function": log_scaling,
+            "kwargs": {
+                "band": "high_green",
+                "scale_from": (2.5, 3.38),
+                "scale_to": (0, 255)
+            }
+        },
+        "blue": {
+            "function": log_scaling,
+            "kwargs": {
+                "band": "high_blue",
+                "scale_from": (2.5, 3.38),
+                "scale_to": (0, 255)
+            }
+        },
+    },
+}
+
 # Create combined list that is imported and passed to the layer
 styles_tidal_composites_list = [
     style_low_true,
@@ -130,4 +194,6 @@ styles_tidal_composites_list = [
     style_low_mndwi,
     style_high_mndwi,
     style_count_clear,
+    low_true_log,
+    high_true_log,
 ]

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/utils_tidal_composites.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/utils_tidal_composites.py
@@ -1,3 +1,15 @@
+from datacube_ows.band_utils import scalable
+
+
+@scalable
+def log_scaling(data, band):
+    """
+    Use log scaling to produce a more visually
+    attractive three-band image.
+    """
+    return (np.log10(data[band] + 1))
+
+
 def tide_graph_path(data, ds):
     """
     Calculates an additional metadata field providing the

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/utils_tidal_composites.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/utils_tidal_composites.py
@@ -8,7 +8,7 @@ def log_scaling(data, band):
     Use log scaling to produce a more visually
     attractive three-band image.
     """
-    return (np.log10(data[band] + 1))
+    return np.log10(data[band] + 1)
 
 
 def tide_graph_path(data, ds):

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/utils_tidal_composites.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/utils_tidal_composites.py
@@ -1,3 +1,4 @@
+import numpy as np
 from datacube_ows.band_utils import scalable
 
 


### PR DESCRIPTION
This PR adds low and high tide threshold layers to OWS so we can hopefully use them in a FeatureInfo popup.

It also adds two experimental log-scaled true colour styles, intended to test whether we can use a single style that works well in dark and bright coastal environments (e.g. avoiding bright beaches from being washed out).