### PR TITLE
Test setting default time on tidal composites, update styling

### DIFF
--- a/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/style_tidal_composites_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/style_tidal_composites_cfg.py
@@ -131,7 +131,7 @@ style_low_true_log = {
             "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
             "kwargs": {
                 "band": "low_red",
-                "scale_from": (2.5, 3.30),
+                "scale_from": (5.5, 7.8),
                 "scale_to": (0, 255)
             }
         },
@@ -139,7 +139,7 @@ style_low_true_log = {
             "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
             "kwargs": {
                 "band": "low_green",
-                "scale_from": (2.5, 3.30),
+                "scale_from": (5.5, 7.8),
                 "scale_to": (0, 255)
             }
         },
@@ -147,7 +147,7 @@ style_low_true_log = {
             "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
             "kwargs": {
                 "band": "low_blue",
-                "scale_from": (2.5, 3.30),
+                "scale_from": (5.5, 7.8),
                 "scale_to": (0, 255)
             }
         },
@@ -164,7 +164,7 @@ style_high_true_log = {
             "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
             "kwargs": {
                 "band": "high_red",
-                "scale_from": (2.5, 3.38),
+                "scale_from": (5.5, 7.8),
                 "scale_to": (0, 255)
             }
         },
@@ -172,7 +172,7 @@ style_high_true_log = {
             "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
             "kwargs": {
                 "band": "high_green",
-                "scale_from": (2.5, 3.38),
+                "scale_from": (5.5, 7.8),
                 "scale_to": (0, 255)
             }
         },
@@ -180,7 +180,7 @@ style_high_true_log = {
             "function": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.log_scaling",
             "kwargs": {
                 "band": "high_blue",
-                "scale_from": (2.5, 3.38),
+                "scale_from": (5.5, 7.8),
                 "scale_to": (0, 255)
             }
         },

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/utils_tidal_composites.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/utils_tidal_composites.py
@@ -8,7 +8,7 @@ def log_scaling(data, band):
     Use log scaling to produce a more visually
     attractive three-band image.
     """
-    return np.log10(data[band] + 1)
+    return np.log(data[band] + 1)
 
 
 def tide_graph_path(data, ds):

--- a/dev/terria/terria-cube-v8.json
+++ b/dev/terria/terria-cube-v8.json
@@ -1101,6 +1101,7 @@
                                     "layers": "ga_s2_tidal_composites_cyear_3",
                                     "linkedWcsUrl": "https://ows.dev.dea.ga.gov.au/",
                                     "linkedWcsCoverage": "ga_s2_tidal_composites_cyear_3",
+                                    "currentTime": "2022",
                                     "dateFormat": "'Year: 'yyyy",
                                     "availableDiffStyles": ["low_true"],
                                     "leafletUpdateInterval": 750,


### PR DESCRIPTION
Set DEA Tidal Composites to default to 2022 data

Use a softer transform (log instead of log10) in experimental layer to improve visualisation