### PR TITLE
convert metadata types from integer to string

### DIFF
--- a/product_metadata/eo3_s1_ard.odc-type.yaml
+++ b/product_metadata/eo3_s1_ard.odc-type.yaml
@@ -120,39 +120,39 @@ dataset:
       description: Whether noise removal has been applied
       offset: [properties, 'nrb:noise_removal_applied']
       indexed: false
-      type: integer
+      type: boolean
 
     # Static tropospheric correction
     static_tropospheric_correction_applied:
       description: Whether static tropospheric correction has been applied
       offset: [properties, 'nrb:static_tropospheric_correction_applied']
       indexed: false
-      type: integer
+      type: boolean
 
     # Wet tropospheric correction
     wet_tropospheric_correction_applied:
       description: Whether wet tropospheric correction has been applied
       offset: [properties, 'nrb:wet_tropospheric_correction_applied']
       indexed: false
-      type: integer
+      type: boolean
 
     # Bistatic correction
     bistatic_correction_applied:
       description: Whether bistatic correction has been applied
       offset: [properties, 'nrb:bistatic_correction_applied']
       indexed: false
-      type: integer
+      type: boolean
 
     # Ionospheric correction
     ionospheric_correction_applied:
       description: Whether ionospheric correction has been applied
       offset: [properties, 'nrb:ionospheric_correction_applied']
       indexed: false
-      type: integer
+      type: boolean
 
     # Speckle filter
     speckle_filter_applied:
       description: Whether a speckle filter has been applied
       offset: [properties, 'nrb:speckle_filter_applied']
       indexed: false
-      type: integer
+      type: boolean

--- a/product_metadata/eo3_s1_ard.odc-type.yaml
+++ b/product_metadata/eo3_s1_ard.odc-type.yaml
@@ -120,39 +120,39 @@ dataset:
       description: Whether noise removal has been applied
       offset: [properties, 'nrb:noise_removal_applied']
       indexed: false
-      type: boolean
+      type: string
 
     # Static tropospheric correction
     static_tropospheric_correction_applied:
       description: Whether static tropospheric correction has been applied
       offset: [properties, 'nrb:static_tropospheric_correction_applied']
       indexed: false
-      type: boolean
+      type: string
 
     # Wet tropospheric correction
     wet_tropospheric_correction_applied:
       description: Whether wet tropospheric correction has been applied
       offset: [properties, 'nrb:wet_tropospheric_correction_applied']
       indexed: false
-      type: boolean
+      type: string
 
     # Bistatic correction
     bistatic_correction_applied:
       description: Whether bistatic correction has been applied
       offset: [properties, 'nrb:bistatic_correction_applied']
       indexed: false
-      type: boolean
+      type: string
 
     # Ionospheric correction
     ionospheric_correction_applied:
       description: Whether ionospheric correction has been applied
       offset: [properties, 'nrb:ionospheric_correction_applied']
       indexed: false
-      type: boolean
+      type: string
 
     # Speckle filter
     speckle_filter_applied:
       description: Whether a speckle filter has been applied
       offset: [properties, 'nrb:speckle_filter_applied']
       indexed: false
-      type: boolean
+      type: string


### PR DESCRIPTION
# Product yaml change PR Template

## Description

Converting types of STAC boolean flags from incorrect `integer` type to `string` type. Integer fails when trying to run summaries in Explorer, and newly added boolean type isn't working for dev datacube.

## Type of change

- [X] Update product metadata

## How Has This Been Tested?

- [X] Test locally

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings