### PR TITLE
Update tidal graph S3 path, also use function for tidal composites

### DIFF
--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/style_intertidal_cfg.py
@@ -354,7 +354,7 @@ style_count_clear = {
     "title": "Clear observation count",
     "abstract": "Count of satellite observations included in DEA Intertidal",
     "custom_includes": {
-        "tide_graph_path": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.tide_graph_path",  # add custom metadata field
+        "tide_graph_path": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.tide_graph_path",  # add custom metadata field
     },
     "index_function": {
         "function": "datacube_ows.band_utils.single_band",

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
@@ -87,7 +87,8 @@ def tide_graph_path(data, ds):
     region_split = region.replace("y", "/y")
 
     # Extract required data from datacube dataset
-    base_dir = "https://dea-public-data.s3-ap-southeast-2.amazonaws.com/derivative"
+    # Tiled data is stored on dev S3, not prod
+    base_dir = "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative"
     product = ds.metadata_doc['properties']['odc:product']
     version = ds.metadata_doc['properties']['odc:dataset_version'].replace(".", "-")
     year = ds.metadata_doc['properties']['datetime'][:4]

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/style_tidal_composites_cfg.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/style_tidal_composites_cfg.py
@@ -3,7 +3,7 @@ style_low_true = {
     "title": "True colour – Low tide",
     "abstract": "Low tide true colour image, using the Red, Green and Blue bands",
     "custom_includes": {
-        "tide_graph_path": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.tide_graph_path",  # add custom metadata field
+        "tide_graph_path": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.tide_graph_path",  # add custom metadata field
     },
     "components": {
         "red": {"low_red": 1.0},
@@ -18,7 +18,7 @@ style_high_true = {
     "title": "True colour – High tide",
     "abstract": "High tide true colour image, using the Red, Green and Blue bands",
     "custom_includes": {
-        "tide_graph_path": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.tide_graph_path",  # add custom metadata field
+        "tide_graph_path": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.tide_graph_path",  # add custom metadata field
     },
     "components": {
         "red": {"high_red": 1.0},
@@ -33,7 +33,7 @@ style_low_false = {
     "title": "False colour – Low tide",
     "abstract": "Low tide false colour image, using the SWIR2, Green and Blue bands",
     "custom_includes": {
-        "tide_graph_path": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.tide_graph_path",  # add custom metadata field
+        "tide_graph_path": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.tide_graph_path",  # add custom metadata field
     },
     "components": {
         "red": {"low_swir_2": 1.0},
@@ -48,7 +48,7 @@ style_high_false = {
     "title": "False colour – High tide",
     "abstract": "High tide false colour image, using the SWIR2, Green and Blue bands",
     "custom_includes": {
-        "tide_graph_path": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.tide_graph_path",  # add custom metadata field
+        "tide_graph_path": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.tide_graph_path",  # add custom metadata field
     },
     "components": {
         "red": {"high_swir_2": 1.0},
@@ -63,7 +63,7 @@ style_low_mndwi = {
     "title": "MNDWI – Low tide",
     "abstract": "Modified Normalised Difference Water Index - a derived index that correlates well with the existence of water (Xu 2006)",
     "custom_includes": {
-        "tide_graph_path": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.tide_graph_path",  # add custom metadata field
+        "tide_graph_path": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.tide_graph_path",  # add custom metadata field
     },
     "index_function": {
         "function": "datacube_ows.band_utils.norm_diff",
@@ -89,7 +89,7 @@ style_high_mndwi = {
     "title": "MNDWI – High tide",
     "abstract": "Modified Normalised Difference Water Index - a derived index that correlates well with the existence of water (Xu 2006)",
     "custom_includes": {
-        "tide_graph_path": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.tide_graph_path",  # add custom metadata field
+        "tide_graph_path": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.tide_graph_path",  # add custom metadata field
     },
     "index_function": {
         "function": "datacube_ows.band_utils.norm_diff",
@@ -115,7 +115,7 @@ style_count_clear = {
     "title": "Clear observation count",
     "abstract": "Count of observations included in tidal composites",
     "custom_includes": {
-        "tide_graph_path": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.tide_graph_path",  # add custom metadata field
+        "tide_graph_path": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.tide_graph_path",  # add custom metadata field
     },
     "index_function": {
         "function": "datacube_ows.band_utils.single_band",
@@ -144,7 +144,7 @@ style_low_true_log = {
     "title": "True colour – Low tide (experimental)",
     "abstract": "Low tide true colour image, using the red, green and blue bands",
     "custom_includes": {
-        "tide_graph_path": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.tide_graph_path",  # add custom metadata field
+        "tide_graph_path": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.tide_graph_path",  # add custom metadata field
     },
     "additional_bands": ["low_red", "low_green", "low_blue"],
     "components": {
@@ -180,7 +180,7 @@ style_high_true_log = {
     "title": "True colour – High tide (experimental)",
     "abstract": "High tide true colour image, using the red, green and blue bands",
     "custom_includes": {
-        "tide_graph_path": "ows_refactored.sea_ocean_coast.tidal_composites_c3.utils_tidal_composites.tide_graph_path",  # add custom metadata field
+        "tide_graph_path": "ows_refactored.sea_ocean_coast.intertidal_c3.utils_intertidal.tide_graph_path",  # add custom metadata field
     },
     "additional_bands": ["high_red", "high_green", "high_blue"],
     "components": {

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/utils_tidal_composites.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/tidal_composites_c3/utils_tidal_composites.py
@@ -9,21 +9,3 @@ def log_scaling(data, band):
     attractive three-band image.
     """
     return np.log(data[band] + 1)
-
-
-def tide_graph_path(data, ds):
-    """
-    Calculates an additional metadata field providing the
-    URL to a graph used to visualise tide biases.
-    """
-
-    # Extract required data from datacube dataset
-    base_dir = "https://dea-public-data.s3-ap-southeast-2.amazonaws.com/derivative"
-    product = ds.metadata_doc['properties']['odc:product']
-    version = ds.metadata_doc['properties']['odc:dataset_version'].replace(".", "-")
-    year = ds.metadata_doc['properties']['datetime'][:4]
-    region = ds.metadata_doc['properties']['odc:region_code']
-    region_split = region.replace("y", "/y")
-
-    # Combine into a string
-    return f"{base_dir}/{product}/{version}/{region_split}/{year}--P1Y/{product}_{region}_{year}--P1Y_final_tide_graph.png"


### PR DESCRIPTION
This PR points the tide graph functionality to tiled tide graphs stored in dev S3, and re-uses the same tide graph function in both Intertidal and Tidal Composites.

This doesn't fix the current OWS coordinates issue, but it will allow the tide graphs to show in locations where that issue does not occur.