### PR TITLE
Extract tide graph coordinates from geobox for coastal products

### DIFF
--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
@@ -1,5 +1,4 @@
 from datacube_ows.band_utils import scalable
-from odc.geo.geom import point
 from odc.geo.gridspec import GridSpec
 from odc.geo.types import xy_
 
@@ -75,11 +74,8 @@ def tide_graph_path(data, ds):
         origin=xy_(-4416000, -6912000),
     )
 
-    # Get point from GetFeatureInfo data. On DEA Maps, we
-    # can assume that `data` coordinates are always in "EPSG:3857"
-    y, x = data.y.item(), data.x.item()
-    point_albers = point(y=y, x=x, crs="EPSG:3857").to_crs("EPSG:3577").geom
-    # point_albers = data.odc.geobox.extent.centroid.to_crs("EPSG:3577").geom
+    # Get point from GetFeatureInfo data
+    point_albers = data.odc.geobox.extent.centroid.to_crs("EPSG:3577").geom
 
     # Return region code
     tile = gs_sentinel_c3.pt2idx(x=point_albers.x, y=point_albers.y)

--- a/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
+++ b/dev/services/wms/ows_refactored/sea_ocean_coast/intertidal_c3/utils_intertidal.py
@@ -1,4 +1,5 @@
 from datacube_ows.band_utils import scalable
+from odc.geo.geom import point
 from odc.geo.gridspec import GridSpec
 from odc.geo.types import xy_
 


### PR DESCRIPTION
This PR reverts our tide graph path generation to use a simpler approach to extract coordinates of the GetFeatureInfo request from the data's `.odc.geobox`.

(essentially reverting back to #1408 now that dev OWS has been updated to return a valid Geobox)