### PR TITLE
Remove 2022 default 'currentTime' from DEA Tidal Composites

### DIFF
--- a/prod/terria/dea-maps-v8.json
+++ b/prod/terria/dea-maps-v8.json
@@ -1208,7 +1208,6 @@
                                     "layers": "ga_s2_tidal_composites_cyear_3",
                                     "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
                                     "linkedWcsCoverage": "ga_s2_tidal_composites_cyear_3",
-                                    "currentTime": "2022",
                                     "dateFormat": "'Year: 'yyyy",
                                     "availableDiffStyles": ["low_mndwi", "high_mndwi"],
                                     "leafletUpdateInterval": 750,


### PR DESCRIPTION
Last year we temporarily set 2022 as the default time that shows for DEA Tidal Composites in DEA Maps, because we felt that the 2023 data was a little noiser. This no longer is the case, so removing it.

This minor change is covered by CAB 20260414.1, and only affects the timestep that is selected by default in DEA Maps for the Tidal Composites product (i.e. it doesn't affect the data itself).