### PR TITLE
Use legacy load driver for S3 Barest Earth (requires OWS 1.9.14)

### DIFF
--- a/dev/services/wms/ows_refactored/land_and_vegetation/ows_barest_earth_cfg.py
+++ b/dev/services/wms/ows_refactored/land_and_vegetation/ows_barest_earth_cfg.py
@@ -43,6 +43,7 @@ IEEE Transactions on Geoscience and Remote Sensing 55 (11), 6254-6264
 
 For service status information, see https://status.dea.ga.gov.au""",
     "product_name": "s2_barest_earth",
+    "load_driver": "legacy",
     "bands": bands_s2_barest_earth,
     "time_resolution": 'summary',
     "resource_limits": reslim_for_sentinel2,


### PR DESCRIPTION
S2 Barest Earth datafiles as currently packaged are not standards compliant COGs and cannot be loaded by the more efficient "rio" load driver.

OWS 1.9.14 supports per-layer over-riding of the load driver, and this PR sets the S2 Barest Earth layer (only) to use the legacy ODC loader.