### PR TITLE
Remove WO version numbers from DEV WMS descriptions

### DIFF
--- a/dev/services/wms/ows_refactored/inland_water/wofs/annual/ows_wofs_annual_cfg.py
+++ b/dev/services/wms/ows_refactored/inland_water/wofs/annual/ows_wofs_annual_cfg.py
@@ -8,7 +8,7 @@ from ows_refactored.ows_reslim_cfg import reslim_standard
 c3_statistics_layer = {
     "title": "DEA Water Observations Calendar Year (Landsat)",
     "name": "ga_ls_wo_fq_cyear_3",
-    "abstract": """**Geoscience Australia Water Observations, Annual Frequency Statistics, Calendar Year (Landsat, Collection 3, 30 m, WO-STATS-ANNUAL, 2.0.0).**
+    "abstract": """**Geoscience Australia Water Observations, Annual Frequency Statistics, Calendar Year (Landsat, Collection 3, 30 m, WO-STATS-ANNUAL).**
 
 The DEA Annual Water Observation Statistic is a set of calendar year statistical summaries of the DEA Water Observations product that combines satellite observations, that occur within each calendar year from 1986 to present, into summary products that help the understanding of surface water across Australia. The layers available are: the count of clear observations; the count of wet observations; and the percentage of wet observations that were observed over the specified time period in the landscape.
 

--- a/dev/services/wms/ows_refactored/inland_water/wofs/individual/ows_c3_wo_cfg.py
+++ b/dev/services/wms/ows_refactored/inland_water/wofs/individual/ows_c3_wo_cfg.py
@@ -6,7 +6,7 @@ from ows_refactored.ows_reslim_cfg import reslim_standard
 layer = {
     "title": "DEA Water Observations (Landsat)",
     "name": "ga_ls_wo_3",
-    "abstract": """**Geoscience Australia Water Observations (Landsat, Collection 3, 30 m, Individual Observations, 2.0.0).**
+    "abstract": """**Geoscience Australia Water Observations (Landsat, Collection 3, 30 m, Individual Observations).**
 
 
 Water Observations are the principal Digital Earth Australia (DEA) Water product (previously known as Water Observations from Space (WOfS)). This product shows where surface water was observed within each individual Landsat (5, 7 and 8) satellite image on each particular day since mid 1986. These daily data layers are termed Water Observations (WOs).

--- a/dev/services/wms/ows_refactored/inland_water/wofs/multiyear/ows_wofs_summary_cfg.py
+++ b/dev/services/wms/ows_refactored/inland_water/wofs/multiyear/ows_wofs_summary_cfg.py
@@ -7,7 +7,7 @@ from ows_refactored.ows_reslim_cfg import reslim_standard
 c3_wofs_layer = {
     "title": "DEA Water Observations Multi Year (Landsat)",
     "name": "ga_ls_wo_fq_myear_3",
-    "abstract": """**Geoscience Australia Water Observations, Multi Year Frequency Statistics, 1986 to near present (Landsat, Collection 3, 30 m, WO-STATS, Frequency, 2.0.0).**
+    "abstract": """**Geoscience Australia Water Observations, Multi Year Frequency Statistics, 1986 to near present (Landsat, Collection 3, 30 m, WO-STATS, Frequency).**
 
 The DEA Multi Year Water Observation Statistic is a statistical summary that combines all years (1986 to near present) of the DEA Water Observations product and helps the understanding of surface water across Australia. The layers available are: the count of clear observations; the count of wet observations; the percentage of wet observations that were observed over the specifed time period in the landscape.
 

--- a/dev/services/wms/ows_refactored/inland_water/wofs/seasonal/ows_wofs_apr_oct_cfg.py
+++ b/dev/services/wms/ows_refactored/inland_water/wofs/seasonal/ows_wofs_apr_oct_cfg.py
@@ -8,7 +8,7 @@ from ows_refactored.ows_reslim_cfg import reslim_standard
 c3_statistics_layer = {
     "title": "DEA Water Observations April to October (Landsat)",
     "name": "ga_ls_wo_fq_apr_oct_3",
-    "abstract": """**Geoscience Australia Water Observations, Seasonal Frequency Statistics, April to October (Landsat, Collection 3, 30 m, WO-STATS-APR-OCT, 2.0.0).**
+    "abstract": """**Geoscience Australia Water Observations, Seasonal Frequency Statistics, April to October (Landsat, Collection 3, 30 m, WO-STATS-APR-OCT).**
 
 The DEA Seasonal Water Observation (April to October) Statistic is a set of seasonal statistical summaries of the DEA Water Observations product. The product combines satellite observations, that occur during April to October within each year, into summary products that help the understanding of surface water across Australia. The layers available are: the count of clear observations; the count of wet observations; and the percentage of wet observations that were observed over the specified time period in the landscape.
 

--- a/dev/services/wms/ows_refactored/inland_water/wofs/seasonal/ows_wofs_nov_mar_cfg.py
+++ b/dev/services/wms/ows_refactored/inland_water/wofs/seasonal/ows_wofs_nov_mar_cfg.py
@@ -8,7 +8,7 @@ from ows_refactored.ows_reslim_cfg import reslim_standard
 c3_statistics_layer = {
     "title": "DEA Water Observations November to March (Landsat)",
     "name": "ga_ls_wo_fq_nov_mar_3",
-    "abstract": """**Geoscience Australia Water Observations, Seasonal Frequency Statistics, November to March (Landsat, Collection 3, 30 m, WO-STATS-NOV-MAR, 2.0.0).**
+    "abstract": """**Geoscience Australia Water Observations, Seasonal Frequency Statistics, November to March (Landsat, Collection 3, 30 m, WO-STATS-NOV-MAR).**
 
 The DEA Seasonal Water Observation (November to March) Statistic is a set of seasonal statistical summaries of the DEA Water Observations product. The product combines satellite observations, that occur during November to March, into summary products that help the understanding of surface water across Australia. The layers available are: the count of clear observations; the count of wet observations; and the percentage of wet observations that were observed over the specified time period in the landscape.
 


### PR DESCRIPTION
Updates the Development Water Observation WMS services by removing the version numbers from the descriptions.
This makes it in line with other services and easier to maintain.

Change requested by @erin-telfer 