### PR TITLE
EPSG:4238 in global OWS config should be EPSG:4283, as per comment.

### DIFF
--- a/dev/services/wms/ows_refactored/ows_root_cfg.py
+++ b/dev/services/wms/ows_refactored/ows_root_cfg.py
@@ -22,7 +22,7 @@ ows_cfg = {
                 "horizontal_coord": "x",
                 "vertical_coord": "y",
             },
-            "EPSG:4238": {  # GDA-94 (geographic) - native CRS for ASTER
+            "EPSG:4283": {  # GDA-94 (geographic) - native CRS for ASTER
                 "geographic": True,
                 "horizontal_coord": "longitude",
                 "vertical_coord": "latitude",

--- a/prod/services/wms/ows_refactored/ows_root_cfg.py
+++ b/prod/services/wms/ows_refactored/ows_root_cfg.py
@@ -22,7 +22,7 @@ ows_cfg = {
                 "horizontal_coord": "x",
                 "vertical_coord": "y",
             },
-            "EPSG:4238": {  # GDA-94 (geographic) - native CRS for ASTER
+            "EPSG:4283": {  # GDA-94 (geographic) - native CRS for ASTER
                 "geographic": True,
                 "horizontal_coord": "longitude",
                 "vertical_coord": "latitude",


### PR DESCRIPTION
An external user noted EPSG:4238 (an Indonesian transform of WGS84) and wondered whether this was a typo for EPSG:4283 (a geographic GDA94 CRS).

The comments indicate this CRS is intended to be the native CRS for the ASTER products, which is indeed EPSG:4283.

This PR fixes this (4 year old) typo in both dev and prod.