### PR TITLE
Update DEA Maps grid URLs to prod

### DIFF
--- a/prod/terria/dea-maps-v8.json
+++ b/prod/terria/dea-maps-v8.json
@@ -1589,13 +1589,13 @@
                                 {
                                     "type": "geojson",
                                     "name": "Sentinel-2 MGRS Tile grid for Australia",
-                                    "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_s2_mgrs_tile_grid.geojson",
+                                    "url": "https://data.dea.ga.gov.au/derivative/ga_s2_mgrs_tile_grid.geojson",
                                     "id": "458eft"
                                 },
                                 {
                                     "type": "geojson",
                                     "name": "Landsat Path Row grid for Australia",
-                                    "url": "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/ga_ls_path_row_grid.geojson",
+                                    "url": "https://data.dea.ga.gov.au/derivative/ga_ls_path_row_grid.geojson",
                                     "id": "fr874s"
                                 },
                                 {


### PR DESCRIPTION
Updates DEA Maps config to point the Sentinel-2 MGRS grid and Landsat path/row grid to prod URLs instead of dea-public-data-dev.

Updated URLs:
- https://data.dea.ga.gov.au/derivative/ga_s2_mgrs_tile_grid.geojson
- https://data.dea.ga.gov.au/derivative/ga_ls_path_row_grid.geojson

Validation:
- Both prod URLs return HTTP/2 200
- Change is limited to two URL updates in prod/terria/dea-maps-v8.json

Note:
- Existing dea-public-data-dev entry in corsDomains was left unchanged, as it is not a dataset URL.